### PR TITLE
added proteinClassification as classes inside proteinAnnotation

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/Target.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Target.scala
@@ -32,10 +32,12 @@ object TargetHelpers {
     def transformReactome: DataFrame = {
       df.withColumn(
         "reactome",
-        when($"reactome".isNotNull,
-             expr("""
-                    |transform(reactome, r -> r.id)
-                    |""".stripMargin))
+        when(
+          $"reactome".isNotNull,
+          expr("""
+                 |transform(reactome, r -> r.id)
+                 |""".stripMargin)
+        )
       )
     }
 
@@ -133,7 +135,8 @@ object TargetHelpers {
           |    uniprot_pathway as pathways,
           |    uniprot_similarity as similarities,
           |    uniprot_subcellular_location as subcellularLocations,
-          |    uniprot_subunit as subunits
+          |    uniprot_subunit as subunits,
+          |    protein_classification.chembl as classes
           |    )
           |end as proteinAnnotations
           |""".stripMargin
@@ -227,10 +230,12 @@ object Target extends LazyLogging {
 
     // TODO THIS NEEDS MORE REFACTORING WORK AS IT CAN BE SIMPLIFIED
     val outputConfs = outputs
-      .map(
-        name =>
-          name -> IOResourceConfig(context.configuration.common.outputFormat,
-                                   context.configuration.common.output + s"/$name"))
+      .map(name =>
+        name -> IOResourceConfig(
+          context.configuration.common.outputFormat,
+          context.configuration.common.output + s"/$name"
+        )
+      )
       .toMap
 
     val outputDFs = (outputs zip Seq(targetDF)).toMap


### PR DESCRIPTION
Added proteinClassification to proteinAnnotations as classes.

Example of behaviour
ENSG00000177000 -> no classes attribute
ENSG00000091831 -> classes attribute

Eg.
```
{
  "proteinAnnotations": {
    "functions": [
      "..."
    ],
    "subcellularLocations": [
      "Nucleus",
      "Cytoplasm",
      "Cell membrane",
      "Golgi apparatus"
    ],
    "similarities": [
      "Belongs to the nuclear hormone receptor family. NR3 subfamily."
    ],
    "subunits": [
      "...."
    ],
    "classes": [
      {
        "l4": {
          "id": 1165,
          "label": "Nuclear hormone receptor subfamily 3 group A"
        },
        "l5": {
          "id": 370,
          "label": "Nuclear hormone receptor subfamily 3 group A member 1"
        },
        "l2": {
          "id": 1033,
          "label": "Nuclear receptor"
        },
        "l3": {
          "id": 1043,
          "label": "Nuclear hormone receptor subfamily 3"
        },
        "l1": {
          "id": 12,
          "label": "Transcription factor"
        }
      }
    ],
    "pathways": [],
    "id": "P03372",
    "accessions": [
      "Q14276",
      "Q13511",
      "P03372",
      "Q6MZQ9",
      "Q9NU51",
      "Q5T5H7",
      "Q9UIS7",
      "Q9UDZ7"
    ]
  },
  "id": "ENSG00000091831"
}
```