### PR TITLE
phewas_catalog incorrect unique association field

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -316,7 +316,7 @@ evidences {
       id: "phewas_catalog",
       unique-fields: [
         "diseaseFromSource",
-        "variantId"
+        "variantRsId"
       ],
       score-expr: "linear_rescale(studyCases, 0.0, 8800.0, 0.0, 1.0) * pvalue_linear_score(resourceScore, 0.5, 1e-25, 0.0, 1.0)"
     },


### PR DESCRIPTION
replacing variantId by variantRsId as UAF in phewas_catalog