### PR TITLE
Added repartition for interaction evidences

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/Interactions.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Interactions.scala
@@ -109,10 +109,10 @@ object InteractionsHelpers extends LazyLogging {
       * @return a DataFrame
       */
     def generateIntacts(
-                         targets: DataFrame,
-                         rnacentral: DataFrame,
-                         humanmapping: DataFrame
-                       ): DataFrame = {
+        targets: DataFrame,
+        rnacentral: DataFrame,
+        humanmapping: DataFrame
+    ): DataFrame = {
       val mappingDF = targets.generateMapping(rnacentral, humanmapping)
       val intactInteractions = df.generateInteractions(mappingDF)
       intactInteractions
@@ -398,7 +398,9 @@ object Interactions extends LazyLogging {
     )
 
     val aggregationInteractions = interactionIntactDF.interactionAggreation(interactionStringsDF)
-    val interactionEvidences = interactionIntactDF.generateEvidences(interactionStringsDF)
+    val interactionEvidences = interactionIntactDF
+      .generateEvidences(interactionStringsDF)
+      .repartitionByRange(500, $"targetA".asc, $"targetB".asc)
 
     Map(
       "interactionEvidences" -> interactionEvidences,
@@ -417,7 +419,7 @@ object Interactions extends LazyLogging {
 
     val outputs = otnetworksDF.keys map (name =>
       name -> Helpers.IOResourceConfig(common.outputFormat, common.output + s"/$name")
-      )
+    )
 
     Helpers.writeTo(outputs.toMap, otnetworksDF)
 


### PR DESCRIPTION
One of the output file was 10GB so we need to reduce the size of the files.
Adding repartitionByRange in order to reduce the size of the files.
