### PR TITLE
Resolves opentargets/platform#1296

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       )
     ),
     name := "io-opentargets-etl-backend",
-    version := "0.4.2",
+    version := "0.4.4",
     resolvers ++= buildResolvers,
     libraryDependencies ++= sparkDeps,
     libraryDependencies ++= aoyi,

--- a/src/main/scala/io/opentargets/etl/backend/drug/Indication.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/Indication.scala
@@ -31,7 +31,7 @@ object Indication extends Serializable with LazyLogging {
     // efoDf for therapeutic areas
     val efoDf = getEfoDataframe(efoRaw)
     val indicationAndEfoDf = processIndicationsRawData(indicationsRaw)
-      .join(efoDf, Seq(efoIdName), "leftouter")
+      .join(efoDf, Seq(efoIdName))
 
     val indicationDf: DataFrame = indicationAndEfoDf
       .withColumn("struct",


### PR DESCRIPTION
Updating join so that efos that are not in the disease index are not
included in the drug dataset. There are approximately 300 indications
removed over 9 EFO ids by this change.