### PR TITLE
Breaking drug step outputs into 'drug', 'mechanism_of_action', and 'indications'

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,10 +194,18 @@ a preconfigured ElasticSearch instance.
 1. Python utility `elasticsearch_loader` must be installed and on your `PATH`
 2. An open port of the ES instance must be forwarded to your local machine and execute the relevant script.
 
-```
-gcloud beta compute ssh --zone "europe-west1-d" "es7-20-09" --project "open-targets-eu-dev" -- -L 9200:localhost:9200
-```  
-3. Update the scripts with the relevant input/output directories
+    ```
+    gcloud beta compute ssh --zone "europe-west1-d" "es7-20-09" --project "open-targets-eu-dev" -- -L 9200:localhost:9200
+    ```  
+
+3. Update the `env.sh` script:
+    - `PREFIX` refers to the path to the data to be loaded into Elasticsearch
+    - `ES` is the url of Elasticsearch
+    - `INDEX_SETTINGS` is the index configuration file. Typically this will be the `index_settings.json` file provided
+   in the _elasticsearch_ directory.
+
+4. Export the necessary environment variables by running `source [path to file]env.sh`
+4. Run scripts relevant to the index you wish to create, or `load_all.sh` to load all of them.  
 
 ## Steps independent of the Data Pipeline
 

--- a/README.md
+++ b/README.md
@@ -280,8 +280,6 @@ The input files are specified in the configuration file under the field `drug-ex
 If the `source` already exists the new references will be appended to the existing ones, provided that the `reference
 ` is not already present. If the `source` does not exist it will be created. 
  
-
- 
 #### Inputs
 
 Inputs are specified in the `reference.conf` file and include the following: 
@@ -294,13 +292,22 @@ Inputs are specified in the `reference.conf` file and include the following:
 |   `drug-chembl-target` | ChEMBL - Platform Input Support |
 |   `drug-drugbank` | Release annotation file |
 
-The `DrugBeta` step also relies on several other sources that we already inputs to the ETL:
+The `Drug` step also relies on several other outputs from the ETL:
 
-| Name in DrugBeta | Field in configuration file |
+| Name in Drug | Field in configuration file |
 | --- | --- |
 | `efo` | disease | 
 | `gene` | target | 
 | `evidence` | evidence | 
+
+#### Outputs
+
+The `Drug` step writes three files under the common directory specified in the `drug.output.path` configuration field:
+  - drugs
+  - mechanismsOfAction
+  - Indications
+  
+Each of these outputs includes a field `id` to allow later linkages between them. 
 
 ## Development environment notes
 

--- a/elasticsearch/env.sh
+++ b/elasticsearch/env.sh
@@ -1,0 +1,3 @@
+export PREFIX="path to data"
+export ES=localhost:9200
+export INDEX_SETTING="foo/bar/index_settings.json"

--- a/elasticsearch/index_settings.json
+++ b/elasticsearch/index_settings.json
@@ -1,21 +1,17 @@
 {
-        "mappings": {
-                "dynamic_templates": [
-                        {
-                                "nesteds": {
-                                        "match_mapping_type": "object",
-                                        "match": "facet_*",
-                                        "mapping": {
-                                                "type": "nested"
-                                        }
-                                }
-                        }
-                ]
-        },
-        "settings": {
-                "index" : {
-                        "number_of_replicas" : 0,
-                        "number_of_shards": 5
-                }
-        }
+  "mappings": {
+    "nesteds": {
+      "match_mapping_type": "object",
+      "match": "facet_*",
+      "mapping": {
+        "type": "nested"
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "number_of_replicas": 0,
+      "number_of_shards": 5
+    }
+  }
 }

--- a/elasticsearch/load_drugs.sh
+++ b/elasticsearch/load_drugs.sh
@@ -1,7 +1,13 @@
 #cat "$1" | elasticsearch_loader --es-host "http://localhost:9200" --index-settings-file "index_settings.json" --bulk-size 5000 --index drugs --type drug --id-field id json --json-lines -
 
-export INDEX_NAME="drug"
-export INPUT="${PREFIX}/drugs"
-export ID="id"
 
-./load_jsons.sh
+subindexes=('drug' 'mechanism_of_action' 'indication')
+
+for si in "${subindexes[@]}"; do
+  export INDEX_NAME=$si
+  export INPUT="${PREFIX}/drugs/$si"
+  export ID="id"
+
+  ./load_jsons.sh
+done
+

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -126,9 +126,19 @@ drug {
       }
     }
   ]
-  output = {
-    format = ${common.output-format}
-    path = ${common.output}"/drugs"
+  outputs = {
+    drug {
+      format = ${common.output-format}
+      path = ${common.output}"/drugs/drug"
+    }
+    mechanism-of-action {
+      format = ${common.output-format}
+      path = ${common.output}"/drugs/mechanism_of_action"
+    }
+    indications {
+      format = ${common.output-format}
+      path = ${common.output}"/drugs/indication"
+    }
   }
 }
 
@@ -143,7 +153,7 @@ known-drugs {
       path = ${common.output}"/targets"
       format = ${common.output-format}
     }
-    drugs = ${drug.output}
+    drugs = ${drug.outputs}
   }
   output {
     format = ${common.output-format}
@@ -500,7 +510,7 @@ search {
       path = ${common.output}"/targets"
       format = ${common.output-format}
     }
-    drugs = ${drug.output}
+    drugs = ${drug.outputs}
     associations = ${associations.outputs.indirect-by-overall}
   }
   outputs {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -100,15 +100,15 @@ drug {
     format = "json"
     path = "gs://ot-snapshots/jsonl/chembl/chembl_27_target-2020-10-08.jsonl"
   }
-  disease-pipeline {
+  disease-etl {
     format = ${common.output-format}
     path = ${common.output}"/diseases"
   }
-  target-pipeline {
+  target-etl {
     format = ${common.output-format}
     path = ${common.output}"/targets"
   }
-  evidence-pipeline = ${evidences.outputs.succeeded}
+  evidence-etl = ${evidences.outputs.succeeded}
   drugbank-to-chembl {
     format = "csv"
     path = "gs://ot-team/jarrod/drugbank/db.csv.gz"

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -70,6 +70,8 @@ object Configuration extends LazyLogging {
   case class InputInfo(format: String, path: String)
 
   case class InputExtension(extensionType: String, input: IOResourceConfig)
+
+  case class DrugOutputs(drug: IOResourceConfig, mechanismOfAction: IOResourceConfig, indications: IOResourceConfig)
   case class DrugSection(
                           chemblMolecule: IOResourceConfig,
                           chemblIndication: IOResourceConfig,
@@ -80,7 +82,7 @@ object Configuration extends LazyLogging {
                           diseaseEtl: IOResourceConfig,
                           targetEtl: IOResourceConfig,
                           evidenceEtl: IOResourceConfig,
-                          output: IOResourceConfig
+                          outputs: DrugOutputs
   )
 
   case class Inputs(
@@ -101,14 +103,14 @@ object Configuration extends LazyLogging {
   case class KnownDrugsInputsSection(evidences: IOResourceConfig,
                                      diseases: IOResourceConfig,
                                      targets: IOResourceConfig,
-                                     drugs: IOResourceConfig)
+                                     drugs: DrugOutputs)
 
   case class KnownDrugsSection(inputs: KnownDrugsInputsSection, output: IOResourceConfig)
 
   case class SearchInputsSection(evidences: IOResourceConfig,
                                  diseases: IOResourceConfig,
                                  targets: IOResourceConfig,
-                                 drugs: IOResourceConfig,
+                                 drugs: DrugOutputs,
                                  associations: IOResourceConfig)
 
   case class SearchOutputsSection(targets: IOResourceConfig,

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -71,16 +71,16 @@ object Configuration extends LazyLogging {
 
   case class InputExtension(extensionType: String, input: IOResourceConfig)
   case class DrugSection(
-      chemblMolecule: IOResourceConfig,
-      chemblIndication: IOResourceConfig,
-      chemblMechanism: IOResourceConfig,
-      chemblTarget: IOResourceConfig,
-      drugbankToChembl: IOResourceConfig,
-      drugExtensions: Seq[InputExtension],
-      diseasePipeline: IOResourceConfig,
-      targetPipeline: IOResourceConfig,
-      evidencePipeline: IOResourceConfig,
-      output: IOResourceConfig
+                          chemblMolecule: IOResourceConfig,
+                          chemblIndication: IOResourceConfig,
+                          chemblMechanism: IOResourceConfig,
+                          chemblTarget: IOResourceConfig,
+                          drugbankToChembl: IOResourceConfig,
+                          drugExtensions: Seq[InputExtension],
+                          diseaseEtl: IOResourceConfig,
+                          targetEtl: IOResourceConfig,
+                          evidenceEtl: IOResourceConfig,
+                          output: IOResourceConfig
   )
 
   case class Inputs(

--- a/src/main/scala/io/opentargets/etl/backend/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Evidence.scala
@@ -1,7 +1,7 @@
 package io.opentargets.etl.backend
 
 import com.typesafe.scalalogging.LazyLogging
-import io.opentargets.etl.backend.spark.Helpers.{IOResourceConfig, mkFlattenArray}
+import io.opentargets.etl.backend.spark.Helpers.{IOResourceConfig, IOResources, mkFlattenArray}
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.analysis.UnresolvedStar
 import org.apache.spark.sql.expressions.Window
@@ -500,9 +500,8 @@ object Evidence extends LazyLogging {
   }
 
   def compute()(implicit context: ETLSessionContext): Map[String, (DataFrame, IOResourceConfig)] = {
-    implicit val ss = context.sparkSession
+    implicit val ss: SparkSession = context.sparkSession
 
-    val commonSec = context.configuration.common
     val evidencesSec = context.configuration.evidences
 
     val mappedInputs = Map(
@@ -556,7 +555,7 @@ object Evidence extends LazyLogging {
     )
   }
 
-  def apply()(implicit context: ETLSessionContext) = {
+  def apply()(implicit context: ETLSessionContext): IOResources = {
     implicit val ss = context.sparkSession
 
     val processedEvidences = compute()

--- a/src/main/scala/io/opentargets/etl/backend/drug/DrugCommon.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/DrugCommon.scala
@@ -23,8 +23,8 @@ object DrugCommon extends Serializable with LazyLogging {
   // columns doesn't clutter logic in the apply method. Note: this should be applied after all other transformations!
   def addDescription(dataFrame: DataFrame): DataFrame = {
     dataFrame
-      .withColumn("_indication_phases", col("indications.rows.maxPhaseForIndication"))
-      .withColumn("_indication_labels", col("indications.rows.efoName"))
+      .withColumn("_indication_phases", col("indications.maxPhaseForIndication"))
+      .withColumn("_indication_labels", col("indications.efoName"))
       .transform(addDescriptionField)
       .drop("_indication_phases", "_indication_labels")
   }

--- a/src/main/scala/io/opentargets/etl/backend/drug/Indication.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/Indication.scala
@@ -40,9 +40,8 @@ object Indication extends Serializable with LazyLogging {
           col("max_phase_for_indications").as("maxPhaseForIndication"),
           col("references")))
       .groupBy("id")
-      .agg(collect_list("struct").as("rows"))
-      .withColumn("count", size(col("rows")))
-      .transform(nest(_: DataFrame, List("rows", "count"), "indications"))
+      .agg(collect_list("struct").as("indications"))
+      .withColumn("count", size(col("indications")))
       .join(approvedIndications(indicationAndEfoDf), Seq("id"), "left_outer")
 
     indicationDf

--- a/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
@@ -72,9 +72,7 @@ object MechanismOfAction extends LazyLogging {
       .agg(collect_list("rows") as "rows",
            collect_set("action_type") as "uniqueActionTypes",
            collect_set("target_type") as "uniqueTargetTypes")
-      .transform(nest(_: DataFrame,
-                      List("rows", "uniqueActionTypes", "uniqueTargetTypes"),
-                      "mechanismsOfAction"))
+
   }
 
   private def chemblMechanismReferences(dataFrame: DataFrame): DataFrame = {

--- a/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
@@ -159,7 +159,8 @@ object Helpers extends LazyLogging {
       c => logger.info(s"save dataset ${c._1} with ${c._2.toString}")
     }
 
-    val outs = outputConfs.keySet intersect outputs.keySet map {
+    // WARNING: SIDE-EFFECTING
+    val outputsSaved = outputConfs.keySet intersect outputs.keySet map {
       case k =>
         val conf = outputConfs(k)
         val df = outputs(k)
@@ -183,13 +184,13 @@ object Helpers extends LazyLogging {
         k -> df
     } toMap
 
-    val intersectKs = outputs.keySet intersect outs.keySet
-    val unionKs = outputs.keySet union outs.keySet
-    (unionKs diff intersectKs).foreach {
+    val savedKeys = outputs.keySet intersect outputsSaved.keySet
+    val allKeys = outputs.keySet union outputsSaved.keySet
+    (allKeys diff savedKeys).foreach {
       k => logger.warn(s"dataframe $k has not been saved")
     }
 
-    outs
+    outputsSaved
   }
 
   /** generate a set of String with the union of Columns.

--- a/src/test/scala/io/opentargets/etl/backend/Drug/IndicationTest.scala
+++ b/src/test/scala/io/opentargets/etl/backend/Drug/IndicationTest.scala
@@ -56,7 +56,7 @@ class IndicationTest extends EtlSparkUnitTest {
     // when
     val results: DataFrame = Indication(indicationDf, efoDf)(sparkSession)
     // then
-    val expectedColumns: Set[String] = Set("id", "indications", "approvedIndications")
+    val expectedColumns: Set[String] = Set("id", "indications", "count", "approvedIndications")
 
     assert(
       results.columns
@@ -73,7 +73,7 @@ class IndicationTest extends EtlSparkUnitTest {
     val indication: DataFrame = Indication(indicationDf, efoDf)
     // when
     val results: DataFrame = indication.select(
-      col("indications.rows.disease").as("efoId"))
+      col("indications.disease").as("efoId"))
       .filter(col("efoId").isNull)
     // then
     assert(results.count() == 0L)


### PR DESCRIPTION
Relates to opentargets/plaform#1308. The output name of mechanism_of_action is so that it is compliant with Elasticsearch's index naming rules. 

Also in this PR:
- Fixed deprecated warning on `elasticseach_loader`