### PR TITLE
update clinvar scoring

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -265,7 +265,7 @@ evidences {
         "variantRsId"
       ],
       score-expr: """
-      array_max(
+      coalesce(array_max(
         transform(
           clinicalSignificances,
           x -> element_at(
@@ -287,7 +287,19 @@ evidences {
               ),
             x)
         )
-      )
+      ), 0.0) + coalesce(element_at(
+        map(
+          'practice guideline', 0.1,
+          'reviewed by expert panel', 0.07,
+          'criteria provided, multiple submitters, no conflicts', 0.05,
+          'criteria provided, conflicting interpretations', 0.02,
+          'criteria provided, single submitter', 0.02,
+          'no assertion for the individual variant', 0.0,
+          'no assertion criteria provided', 0.0,
+          'no assertion provided', 0.0
+        ),
+        confidence
+      ), 0.0)
       """
     },
     {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -233,7 +233,7 @@ evidences {
         "variantRsId"
       ],
       score-expr: """
-      array_max(
+      coalesce(array_max(
         transform(
           clinicalSignificances,
           x -> element_at(
@@ -255,7 +255,19 @@ evidences {
               ),
             x)
         )
-      )
+      ), 0.0) + coalesce(element_at(
+        map(
+          'practice guideline', 0.1,
+          'reviewed by expert panel', 0.07,
+          'criteria provided, multiple submitters, no conflicts', 0.05,
+          'criteria provided, conflicting interpretations', 0.02,
+          'criteria provided, single submitter', 0.02,
+          'no assertion for the individual variant', 0.0,
+          'no assertion criteria provided', 0.0,
+          'no assertion provided', 0.0
+        ),
+        confidence
+      ), 0.0)
       """
     },
     {

--- a/src/main/scala/io/opentargets/etl/backend/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Evidence.scala
@@ -168,7 +168,7 @@ object Evidence extends LazyLogging {
       H.trans(coalesce(col("evidence.drug2clinic.status"), lit("N/A")),
               _ => "clinicalStatus",
               co => when(col("sourceID") === "chembl", co)),
-      flattenCAndSetN(col("evidence.drug2clinic.urls"), _ => "clinicalUrls"),
+      flattenCAndSetN(col("evidence.drug2clinic.urls"), _ => "urls"),
       H.trans(col("evidence.gene2variant.functional_consequence"),
               _ => "variantFunctionalConsequenceId",
               H.stripIDFromURI),


### PR DESCRIPTION
Update scores for `eva` and `eva_somatic` as indicated in opentargets/platform/issues/1319