### PR TITLE
Removing Java11 methods to run in Dataproc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ OpenTargets ETL pipeline to process Pipeline output in order to obtain a new API
 
 ### Requirements
 
-1. OpenJDK 11
+1. OpenJDK 8/11
 2. scala 2.12.x (through SDKMAN is simple)
 3. ammonite REPL
 4. Drug index dump from OpenTargets ES
@@ -19,9 +19,16 @@ OpenTargets ETL pipeline to process Pipeline output in order to obtain a new API
 8. Expression index dump from OpenTargets ES
 9. Generate MousePhenotypes dump from OperTargets ES
 
+#### Notes on Java version
+
+Either Java 8 or 11 can be used to build and run the project, but if you intend to use the compiled jar file on
+_Dataproc_ you must use Java 8. To avoid this problem altogether, do not use native Java methods unless strictly
+necessary.
+
 ### Generate the indices dump from ES7
 
 You will need to either connect to a machine containing the ES or forward the ssh port from it
+
 ```sh
 elasticdump --input=http://localhost:9200/<indexyouneed> \
     --output=<indexyouneed>.json \

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       )
     ),
     name := "io-opentargets-etl-backend",
-    version := "0.4.5",
+    version := "0.4.6",
     resolvers ++= buildResolvers,
     libraryDependencies ++= sparkDeps,
     libraryDependencies ++= aoyi,

--- a/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
@@ -170,7 +170,7 @@ object Helpers extends LazyLogging {
     */
   private def generateMetadata(ior: IOResource, withConfig: IOResourceConfig)(
       implicit context: ETLSessionContext): IOResource = {
-    require(!withConfig.path.isBlank, "metadata resource path cannot be empty")
+    require(withConfig.path.nonEmpty, "metadata resource path cannot be empty")
     implicit val session: SparkSession = context.sparkSession
     import session.implicits._
 
@@ -181,10 +181,10 @@ object Helpers extends LazyLogging {
         .modify(
           _.stripPrefix(context.configuration.common.output)
             .split("/")
-            .filterNot(_.isBlank)
+            .filter(_.nonEmpty)
             .mkString("/", "/", ""))
     val cols = ior.data.columns.toList
-    val id = ior.configuration.path.split("/").filterNot(_.isBlank).last
+    val id = ior.configuration.path.split("/").filter(_.nonEmpty).last
     val newPath = withConfig.path + s"/$id"
     val metadataConfig = withConfig.lens(_.path).set(newPath)
 


### PR DESCRIPTION
Removed native Java calls and replaced with Scala. 
I left some notes in the README explaining why it's necessary to use Java 8.