### PR TITLE
Update Molecule to handle missing 'drugType' values

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
@@ -64,7 +64,9 @@ object Molecule extends LazyLogging {
         col("molecule_chembl_id").as("id"),
         col("molecule_structures.canonical_smiles").as("canonicalSmiles"),
         col("molecule_structures.standard_inchi_key").as("inchiKey"),
-        col("molecule_type").as("drugType"),
+        when(col("molecule_type").isNotNull, col("molecule_type"))
+          .otherwise("unknown")
+          .as("drugType"),
         col("chebi_par_id"),
         col("black_box_warning").as("blackBoxWarning"),
         col("pref_name").as("name"),

--- a/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
@@ -64,9 +64,7 @@ object Molecule extends LazyLogging {
         col("molecule_chembl_id").as("id"),
         col("molecule_structures.canonical_smiles").as("canonicalSmiles"),
         col("molecule_structures.standard_inchi_key").as("inchiKey"),
-        when(col("molecule_type").isNotNull, col("molecule_type"))
-          .otherwise("unknown")
-          .as("drugType"),
+        coalesce(col("molecule_type"), lit("unknown")).as("drugType"),
         col("chebi_par_id"),
         col("black_box_warning").as("blackBoxWarning"),
         col("pref_name").as("name"),


### PR DESCRIPTION
Each molecule should have a 'moleculeType' which we rename to
`drugType`. This field is missing for at least one molecule
which breaks the API when it attempts to retrieve the field.