### PR TITLE
Draft

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -61,6 +61,8 @@ reactome {
         {k: "header", v: "false"}
         {k: "inferSchema", v: "true"}
       ]
+      index-name = "reactome"
+      index-id = "id"
     }
     relations {
       format = "csv"

--- a/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/Helpers.scala
@@ -23,7 +23,9 @@ object Helpers extends LazyLogging {
       format: String,
       path: String,
       options: Option[Seq[IOResourceConfigOption]] = None,
-      partitionBy: Option[Seq[String]] = None
+      partitionBy: Option[Seq[String]] = None,
+      indexName: Option[String] = None,
+      indexId: Option[String] = None
   )
 
   case class Metadata(id: String,


### PR DESCRIPTION
@JarrodBaker, @mbdebian and @mkarmona 
To avoid to hardcode the name of the index inside the script I would like to use the metadata to export the name of the index.

This is an example of the output
 ```
 "resource": {
    "format": "json",
    "path": "/reactome",
    "indexName": "reactome",
    "indexId": "id"
  },
```