### PR TITLE
Normalize PhenoDigm score

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -485,7 +485,7 @@ evidences {
         "targetInModel",
         "biologicalModelGeneticBackground"
       ],
-      score-expr: "resourceScore"
+      score-expr: "resourceScore / 100"
     },
     {
       id: "phewas_catalog",


### PR DESCRIPTION
The score for PhenoDigm is from now on not normalised in the parser when generating the evidence. 
This is an update of the score expression to do this step in the ETL.