### PR TITLE
Adding two new clinical significance terms

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -324,11 +324,13 @@ evidences {
               'not provided', 0.0,
               'likely benign', 0.0,
               'conflicting interpretations of pathogenicity', 0.3,
+              'conflicting data from submitters': 0.3,
               'other', 0.3,
               'uncertain significance', 0.3,
               'risk factor', 0.5,
               'affects', 0.5,
               'likely pathogenic', 0.7,
+              'confers sensitivity': 0.9
               'association', 0.9,
               'drug response', 0.9,
               'protective', 0.9,


### PR DESCRIPTION
The EVA team submitting updated evidence for the 21.06 release. In this updated dataset there are evidence strings for which the disease terms could not be mapped to EFO. Some of these new disease terms fall into yet unseen clinical significance categories. These categories with the appropriate weights are added to this config file.

Based on the data team stand-up discussion, we came up it the following weights of the new terms.