### PR TITLE
fix: resolve targets function doesnt need to use symbo synonyms

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Evidence.scala
@@ -116,8 +116,7 @@ object Evidence extends LazyLogging {
               array(col("id")),
               array(col("proteinAnnotations.id")),
               col("proteinAnnotations.accessions"),
-              array(col("approvedSymbol")),
-              col("symbolSynonyms")
+              array(col("approvedSymbol"))
             )).as("rIds"),
         )
         .withColumn("rId", explode(col("rIds")))


### PR DESCRIPTION
Fixes #opentargets/platform/issues/1598