### PR TITLE
Add write mode configuration to `reference.conf`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ The `options` field configures how Spark will read the input files. Both Json an
 configurable options, details of which can be
 found [in the documentation](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html)
 
+#### Configuring Spark
+
 If you want to use a local installation of Spark customise the `application.conf` with the following spark-uri field and
 adjust any other fields as necessary from the `reference.conf` template:
 
@@ -80,10 +82,16 @@ common {
 }
 ```
 
+By default Spark will only write to non-existent directories. This behaviour can be modified using the settings field
+`spark-settings.write-mode` using one of the valid inputs "error", "errorifexists", "append", "overwrite", "ignore".
+
+#### Configuring Loggging
+
 Similarly update the logback configuration. You can add `-Dlogback.configurationFile=application.xml` and have a
 logback.xml hanging on your project root or run path. An example log configuration file:
 
 ```xml
+
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,14 @@
 spark-uri = null
+
+spark-settings {
+  // Specifies the behavior when data or table already exists. Options include:
+  //   overwrite: overwrite the existing data.
+  //   append: append the data.
+  //   ignore: ignore the operation (i.e. no-op).
+  //   error or errorifexists: default option, throw an exception at runtime.
+  // Taken from `DataFrameWrite.scala` scaladoc.
+  write-mode = "error"
+}
 common {
   default-steps = [
     "reactome",

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -198,8 +198,15 @@ object Configuration extends LazyLogging {
 
   case class TargetOutput(target: IOResourceConfig)
 
+  case class SparkSettings(writeMode: String) {
+    val validWriteModes = Set("error", "errorifexists", "append", "overwrite", "ignore")
+    require(validWriteModes.contains(writeMode),
+            s"$writeMode is not valid. Must be one of ${validWriteModes.toString()}")
+  }
+
   case class OTConfig(
       sparkUri: Option[String],
+      sparkSettings: SparkSettings,
       common: Common,
       cancerbiomarkers: CancerBiomarkersSection,
       reactome: ReactomeSection,

--- a/src/main/scala/io/opentargets/etl/backend/spark/IoHelpers.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/IoHelpers.scala
@@ -97,6 +97,9 @@ object IoHelpers extends LazyLogging {
   private def writeTo(output: IOResource)(implicit context: ETLSessionContext): IOResource = {
     implicit val spark: SparkSession = context.sparkSession
 
+    val writeMode = context.configuration.sparkSettings.writeMode
+    logger.debug(s"Write mode set to $writeMode")
+
     logger.info(s"save IOResource ${output.toString}")
     val data = output.data
     val conf = output.configuration
@@ -116,6 +119,7 @@ object IoHelpers extends LazyLogging {
 
       }
       .format(conf.format)
+      .mode(writeMode)
       .save(conf.path)
 
     output

--- a/src/test/scala/io/opentargets/etl/ConfigurationTest.scala
+++ b/src/test/scala/io/opentargets/etl/ConfigurationTest.scala
@@ -11,12 +11,25 @@ class ConfigurationTest extends AnyFlatSpecLike with Matchers with LazyLogging {
   "Pureconfig" should "successfully load standard configuration without error" in {
     val conf: ConfigReader.Result[OTConfig] = Configuration.config
     val msg = conf match {
-      case Right(_) => logger.info("configuration loaded right")
+      case Right(_) =>
+        logger.info("configuration loaded right")
         None
-      case Left(ex) => logger.info(s"Failed to load configuration in ${ex.prettyPrint()}")
+      case Left(ex) =>
+        logger.info(s"Failed to load configuration in ${ex.prettyPrint()}")
         Some(ex.prettyPrint())
     }
 
     assert(conf.isRight, s"Failed with ${msg.getOrElse("")}")
+  }
+
+  "SparkSettings" should "only accept valid write modes as input parameters" in {
+    // given
+    val invalidMode = "concatenate"
+    val validModes = Seq("error", "errorifexists", "append", "overwrite", "ignore")
+    // when
+    val settings = validModes.map(SparkSettings)
+    // then
+    assertThrows[IllegalArgumentException](SparkSettings(invalidMode))
+    assertResult(validModes.sorted)(settings.map(_.writeMode).sorted)
   }
 }


### PR DESCRIPTION
I'm tired of accidentally forgetting to delete test output files when developing locally and having test runs fail. My little workaround. 