### PR TITLE
Mouse phenotypes rewrite (data pipeline deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ elasticdump --input=http://localhost:9200/<indexyouneed> \
     --sourceOnly
 ```
 
-### Mouse Phenotype input for ETL
+### Mouse Phenotype input for ETL (deprecated as of 21.06 release!)
 
 Generate MousePhenotypes input file
 
@@ -316,16 +316,28 @@ The `Drug` step also relies on several other outputs from the ETL:
 #### Outputs
 
 The `Drug` step writes three files under the common directory specified in the `drug.output.path` configuration field:
-  - drugs
-  - mechanismsOfAction
-  - Indications
-  
-Each of these outputs includes a field `id` to allow later linkages between them. 
+
+- drugs
+- mechanismsOfAction
+- Indications
+
+Each of these outputs includes a field `id` to allow later linkages between them.
+
+### Mouse Phenotypes
+
+#### Inputs
+
+| Input | Source | Notes |
+| --- | --- | --- |
+| mp-classes | PIS | This is preprocessed by PIS using a project `opentargets-ontologyutils` to extract needed data from an OWL file in jsonl format. |
+| mp-report | PIS | |
+| mp-orthology | PIS | |
+| mp-categories | Static | This file was a hard-coded map in the deprecated data-pipeline. |
 
 ### Target
 
-These notes refer to the Target step as rewritten in March 2021. If attempting to debug datasets completed before 
-release 20.XX consult commits preceeding XXXXXX. 
+These notes refer to the Target step as rewritten in March 2021. If attempting to debug datasets completed before
+release 20.XX consult commits preceeding XXXXXX.
 
 #### Inputs
 

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Each of these outputs includes a field `id` to allow later linkages between them
 | mp-report | PIS | |
 | mp-orthology | PIS | |
 | mp-categories | Static | This file was a hard-coded map in the deprecated data-pipeline. |
+| target | ETL | Output of target step of ETL | 
 
 ### Target
 

--- a/documentation/etl_current.puml
+++ b/documentation/etl_current.puml
@@ -18,7 +18,7 @@ artifact evidence <<dependencies>>
 artifact expression <<noDependency>>
 artifact interactions <<dependencies>>
 artifact knownDrugs <<dependencies>>
-artifact mousePhenotypes <<noDependency>>
+artifact mousePhenotypes <<dependencies>>
 artifact reactome <<noDependency>>
 artifact search <<dependencies>>
 artifact target <<noDependency>>
@@ -35,6 +35,8 @@ disease --> associationOTF
 target --> associationOTF
 
 target --> cancerBiomarkers
+
+target --> mousePhenotypes
 
 target --> drug
 disease --> drug

--- a/documentation/etl_current_full.puml
+++ b/documentation/etl_current_full.puml
@@ -18,7 +18,7 @@ artifact evidence <<dependencies>>
 artifact expression <<noDependency>>
 artifact interactions <<dependencies>>
 artifact knownDrugs <<dependencies>>
-artifact mousePhenotypes <<noDependency>>
+artifact mousePhenotypes <<dependencies>>
 artifact reactome <<noDependency>>
 artifact search <<dependencies>>
 artifact target <<noDependency>>
@@ -58,7 +58,10 @@ interface intact <<input>>
 interface strings <<input>>
 ' known drugs
 ' mouse phenotypes
-interface mousePhenotypesData <<input>>
+interface mpClasses <<input>>
+interface mpReport <<input>>
+interface mpOrthology <<input>>
+interface mpCategories <<input>>
 ' reactome
 interface pathways <<input>>
 interface relations <<input>>
@@ -220,7 +223,11 @@ mechanismOfActionOutput --> knownDrugs
 knownDrugs --> knownDrugsOutput
 
   ' mouse phenotypes
-mousePhenotypesData --> mousePhenotypes
+mpClasses --> mousePhenotypes
+mpCategories --> mousePhenotypes
+mpReport --> mousePhenotypes
+mpOrthology --> mousePhenotypes
+targetOutput --> mousePhenotypes
 mousePhenotypes --> mousePhenotypesOutput
 
   ' reactome

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -856,6 +856,7 @@ mouse-phenotypes {
       {k: "header", v: true},
     ]
   }
+  target = ${target.outputs.target}
   output {
     format = ${common.output-format}
     path = ${common.output}"/mousePhenotypes"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -826,8 +826,40 @@ evidences {
         confidence
       )
       """
-    }    
+    }
   ]
+}
+
+mouse-phenotypes {
+  mp-classes {
+    format = "json"
+    path = ${common.input}"/annotation-files/mp/mp-ontology*.jsonl"
+  }
+  mp-orthology {
+    format = "csv"
+    path = ${common.input}"/annotation-files/HMD_HumanPhenotype-*.rpt"
+    options = [
+      {k: "sep", v: "\\t"},
+    ]
+  }
+  mp-reports {
+    format = "csv"
+    path = ${common.input}"/annotation-files/MGI_PhenoGenoMP*.rpt"
+    options = [
+      {k: "sep", v: "\\t"},
+    ]
+  }
+  mp-categories {
+    format = "csv"
+    path = ${common.input}"/annotation-files/phenotype_categories.csv"
+    options = [
+      {k: "header", v: true},
+    ]
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/mousePhenotypes"
+  }
 }
 
 associations {

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -36,7 +36,7 @@ object ETL extends LazyLogging {
         Disease()
       case "target" =>
         logger.info("run step target")
-        Target()
+        target.Target()
       case "mousePhenotypes" =>
         logger.info("run step mousephenotypes")
         MousePhenotypes()

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -151,6 +151,12 @@ object Configuration extends LazyLogging {
 
   case class KnownDrugsSection(inputs: KnownDrugsInputsSection, output: IOResourceConfig)
 
+  case class MousePhenotypes(mpClasses: IOResourceConfig,
+                             mpReports: IOResourceConfig,
+                             mpOrthology: IOResourceConfig,
+                             mpCategories: IOResourceConfig,
+                             output: IOResourceConfig)
+
   case class SearchInputsSection(evidences: IOResourceConfig,
                                  diseases: IOResourceConfig,
                                  diseaseHpo: IOResourceConfig,
@@ -216,6 +222,7 @@ object Configuration extends LazyLogging {
       knownDrugs: KnownDrugsSection,
       search: SearchSection,
       aotf: AOTFSection,
-      target: Target
+      target: Target,
+      mousePhenotypes: MousePhenotypes
   )
 }

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -155,6 +155,7 @@ object Configuration extends LazyLogging {
                              mpReports: IOResourceConfig,
                              mpOrthology: IOResourceConfig,
                              mpCategories: IOResourceConfig,
+                             target: IOResourceConfig,
                              output: IOResourceConfig)
 
   case class SearchInputsSection(evidences: IOResourceConfig,

--- a/src/main/scala/io/opentargets/etl/backend/MousePhenotypes.scala
+++ b/src/main/scala/io/opentargets/etl/backend/MousePhenotypes.scala
@@ -2,36 +2,155 @@ package io.opentargets.etl.backend
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql._
-import org.apache.spark.sql.types._
-import com.typesafe.config.Config
-import io.opentargets.etl.backend.spark.{Helpers, IOResource, IOResourceConfig, IoHelpers}
+import io.opentargets.etl.backend.spark.{IOResource, IOResourceConfig, IoHelpers}
 import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import org.apache.spark.sql.functions.{
+  array_distinct,
+  broadcast,
+  col,
+  collect_list,
+  collect_set,
+  explode,
+  regexp_extract,
+  split,
+  struct,
+  transform,
+  translate,
+  trim
+}
 
-// This is option/step MousePhenotypes in the config file. JQ file input
 object MousePhenotypes extends LazyLogging {
+
   def apply()(implicit context: ETLSessionContext): IOResources = {
     implicit val ss: SparkSession = context.sparkSession
 
-    val dfName = "mousePhenotypes"
-    val common = context.configuration.common
+    val mpDF = compute(context)
+
+    val dataframesToSave: IOResources = Map(
+      "mousePhenotypes" -> IOResource(mpDF, context.configuration.mousePhenotypes.output)
+    )
+
+    IoHelpers.writeTo(dataframesToSave)
+
+  }
+
+  def compute(context: ETLSessionContext)(implicit ss: SparkSession): DataFrame = {
+    val config = context.configuration.mousePhenotypes
     val mappedInputs = Map(
-      dfName -> IOResourceConfig(
-        common.inputs.mousephenotypes.format,
-        common.inputs.mousephenotypes.path
+      "mp" -> IOResourceConfig(
+        config.mpClasses.format,
+        config.mpClasses.path
+      ),
+      "reports" -> IOResourceConfig(
+        config.mpReports.format,
+        config.mpReports.path
+      ),
+      "orthology" -> IOResourceConfig(
+        config.mpOrthology.format,
+        config.mpOrthology.path
+      ),
+      "categories" -> IOResourceConfig(
+        config.mpCategories.format,
+        config.mpCategories.path
       )
     )
     val inputDataFrame = IoHelpers.readFrom(mappedInputs)
-    val mousePhenotypesDF = inputDataFrame(dfName).data
 
-    val outputs = Map(
-      dfName -> IOResource(
-        mousePhenotypesDF,
-        IOResourceConfig(
-          context.configuration.common.outputFormat,
-          context.configuration.common.output + s"/$dfName"
+    val mousePhenotypesRawDF = inputDataFrame("mp").data
+    val reportsRawDF = inputDataFrame("reports").data
+      .toDF("human_gene_symbol", "a", "b", "c", "gene_symbol", "gene_id", "phenotypes_raw", "d")
+      .drop("a", "b", "c", "d")
+    val orthologyRawDF = inputDataFrame("orthology").data
+      .toDF("allelic_composition",
+            "allele_symbol",
+            "genetic_background",
+            "mp_id",
+            "pmid",
+            "mouse_gene_ids")
+      .drop("allele_symbol")
+    val categoriesRawDF = inputDataFrame("categories").data
+      .select(
+        col("mp") as "category_mp_identifier",
+        col("category") as "category_mp_label"
+      )
+
+    // prepare othology
+    val orthologyDF = orthologyRawDF
+      .filter(col("phenotypes_raw").isNotNull)
+      .withColumn("phenotypes_summary", split(col("phenotypes_raw"), ","))
+      .withColumn("phenotypes_summary",
+                  transform(col("phenotypes_summary"), (a: Column) => trim(a)))
+      .drop("phenotypes_raw")
+      .groupBy(
+        "gene_symbol",
+        "gene_id",
+        "phenotypes_summary"
+      )
+      .agg(collect_set(col("human_gene_symbol")) as "human_genes")
+
+    // prepare reports
+    val reportsDF = reportsRawDF
+      .withColumn("mp_id", translate(col("mp_id"), ":", "_"))
+      .withColumn("gene_id", explode(split(col("mouse_gene_ids"), "\\|")))
+      .drop("mouse_gene_ids")
+
+    // prepare mp
+    val mousePhenotypesDF = mousePhenotypesRawDF
+      .withColumn("mp_id", regexp_extract(col("id"), "MP_\\d+", 0))
+      .drop("id", "path")
+
+    // gene_id, mp_id, allelic_composition, genetic_background, pmid, label, path_codes, gene_symbol,
+    // phenotypes_summary, human_genes
+    val mpAndHumanGeneDf =
+      reportsDF.join(mousePhenotypesDF, Seq("mp_id")).join(orthologyDF, Seq("gene_id"))
+
+    // gene_id, path_codes, gene_symbol, phenotypes_summary, human_genes, genetype_phenotype
+    val mpWithNestedGenotypePhenotypeDF = mpAndHumanGeneDf
+      .withColumn(
+        "genotype_phenotype",
+        struct(
+          col("allelic_composition") as "subject_allelic_composition",
+          col("genetic_background") as "subject_background",
+          col("pmid"),
+          col("mp_id") as "mp_identifier",
+          col("label") as "mp_label"
         )
       )
-    )
-    IoHelpers.writeTo(outputs)
+      .drop("allelic_composition", "genetic_background", "pmid", "mp_id", "label")
+
+    // gene_id, gene_symbol, human_genes, genotype_phenotype, category_mp_identifier
+    val withCategoryMpIdentifierDF = mpWithNestedGenotypePhenotypeDF
+      .withColumn(
+        "category_mp_identifier",
+        array_distinct(transform(col("path_codes"), (a: Column) => translate(a(0), "_", ":"))))
+      .withColumn("category_mp_identifier", explode(col("category_mp_identifier")))
+      .drop("path_codes", "phenotypes_summary")
+
+    // gene_id, gene_symbol, human_genes, genotype_phenotype, category_mp_identifier, category_mp_label
+    val withCategoryMpLabelDF =
+      withCategoryMpIdentifierDF.join(broadcast(categoriesRawDF), "category_mp_identifier")
+
+    // "gene_id", "gene_symbol", "human_genes", "category_mp_identifier", "category_mp_label",
+    // "genotype_phenotype"
+    val groupedByGenotypePhenotypeDF = withCategoryMpLabelDF
+      .groupBy("gene_id",
+               "gene_symbol",
+               "human_genes",
+               "category_mp_identifier",
+               "category_mp_label")
+      .agg(collect_list("genotype_phenotype") as "genotype_phenotype")
+
+    val groupedByHumanAndMouseGene = groupedByGenotypePhenotypeDF
+      .select(
+        col("human_genes"),
+        col("gene_id") as "mouse_gene_id",
+        col("gene_symbol") as "mouse_gene_symbol",
+        struct(col("category_mp_identifier"), col("category_mp_label"), col("genotype_phenotype")) as "phenotypes"
+      )
+      .groupBy("human_genes", "mouse_gene_id", "mouse_gene_symbol")
+      .agg(collect_set("phenotypes") as "phenotypes")
+
+    ???
   }
+
 }

--- a/src/main/scala/io/opentargets/etl/backend/target/Hgnc.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Hgnc.scala
@@ -32,7 +32,7 @@ object Hgnc extends LazyLogging {
         col("symbol") as "approvedSymbol",
         col("name") as "approvedName",
         col("uniprot_ids"),
-        safeArrayUnion(col("alias_symbol"), col("alias_name")) as "hgncSynonyms"
+        safeArrayUnion(col("prev_symbol"), col("alias_symbol"), col("alias_name")) as "hgncSynonyms"
       )
       .transform(Helpers.snakeToLowerCamelSchema)
 

--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -27,7 +27,7 @@ case class SafetyEvidence(event: String,
                           datasource: String,
                           pmid: String,
                           url: String,
-                          assay: Array[TargetSafetyAssay])
+                          assays: Array[TargetSafetyAssay])
 case class SafetyTissue(label: String, efoId: String, modelName: String)
 
 object Safety extends LazyLogging {
@@ -153,9 +153,7 @@ object Safety extends LazyLogging {
           col("datasource"),
           col("pmid"),
           col("url"),
-          col("assayDescription"),
-          col("assayFormat"),
-          col("assayType")
+          col("assays")
         ) as "safety"
       )
       .groupBy("id")


### PR DESCRIPTION
The main purpose of this PR is to deprecate the MousePhenotypes (MP) component of the DP. MP was generated as part of the target step which we want to remove for 21.09. This is a _direct port_ of the logic, and as far as I've been able to test we have actually gone from 11950 MP entries to 13089.

Two mouse genes could not be mapped to Ensembl IDs.

```
+---------------+--------------+-----------------+-----------+
|             id|approvedSymbol|mouse_gene_symbol|human_genes|
+---------------+--------------+-----------------+-----------+
|ENSG00000287542|              |            Herc3|    [HERC3]| < AC issue
|ENSG00000205045|              |            Slfn4|  [SLFN12L]| < AC issue
+---------------+--------------+-----------------+-----------+
```
It looks like both of these failures result from the approved symbol changing in the latest Ensembl release (they were both AC...). Neither have MP listed in the current release. The MP associated with HERC3 are captured by ENSG00000138641. 

Enhancements:
- HGNC now includes previous symbols in the synonyms for Target. This was necessary to increase the mapping coverage of MP as it uses gene symbols to link with Ensembl IDs. These previous terms are also listed as synonyms on the current platform, so I'm guessing it is intended behaviour which was missed in there earlier stages of the target re-write. 

Bugfixes: 

- Target safety was selecting the wrong fields and crashing 