### PR TITLE
Target step updates: alternative gene and gene ontology

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/GeneOntology.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/GeneOntology.scala
@@ -116,6 +116,9 @@ object GeneOntology extends LazyLogging {
       .withColumn("ensemblId", regexp_extract(col("ensemblId"), "ENSG[0-9]+", 0))
   }
 
+  /**
+    * @return dataframe with columns 'ensemblId', 'uniprotId'
+    */
   private def ensemblDfToHumanLookupTable(dataset: Dataset[Ensembl])(
       implicit sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
@@ -124,8 +127,8 @@ object GeneOntology extends LazyLogging {
       .map(row => {
         val ensembId = row.id
         val accessions = row.proteinIds
-          .withFilter(_.source.equalsIgnoreCase("Uniprot"))
-          .map(pids => pids.id)
+          .withFilter(_.source.contains("uniprot"))
+          .map(pids => pids.id) :+ row.approvedSymbol
         (ensembId, accessions.distinct)
       })
       .toDF("ensemblId", "uniprotId")


### PR DESCRIPTION
- Fixed logic bug where `alternativeGenes` on non-canonical chromosomes which shared an approved symbol with a canonical gene were not properly grouped
- Gene Ontology (`go`) needs to be mapped to a uniprot `proteinId`. These protein ids are extracted from the Uniprot input, and can be labelled 'uniprot_trembl' or 'uniport_swissprot'. This change ensures we collect all the values we need for the merge.