### PR TITLE
1547 create gene ontology index

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,20 @@ The `Drug` step writes three files under the common directory specified in the `
 
 Each of these outputs includes a field `id` to allow later linkages between them.
 
+### GO
+
+The 'Go' step generates a small lookup table of gene ontologies.
+
+#### Inputs
+
+| Input | Source | Notes |
+| --- | --- | --- |
+| go-input | PIS | Provided by PIS from http://geneontology.org/docs/download-ontology/#go_obo_and_owl |
+
+The input is a flat file which does not lend itself to columnar processing so its currently a 'preprocessor' step. If
+more complicated logic becomes required this should be ported. There is also to option of querying the EBI API but this
+is quite slow and results in a moderately large dataset which we don't otherwise need.
+
 ### Mouse Phenotypes
 
 #### Inputs

--- a/documentation/etl_current.puml
+++ b/documentation/etl_current.puml
@@ -16,6 +16,7 @@ artifact drug <<dependencies>>
 artifact eco <<noDependency>>
 artifact evidence <<dependencies>>
 artifact expression <<noDependency>>
+artifact go <<noDependency>>
 artifact interactions <<dependencies>>
 artifact knownDrugs <<dependencies>>
 artifact mousePhenotypes <<dependencies>>

--- a/documentation/etl_current_full.puml
+++ b/documentation/etl_current_full.puml
@@ -16,6 +16,7 @@ artifact drug <<dependencies>>
 artifact eco <<noDependency>>
 artifact evidence <<dependencies>>
 artifact expression <<noDependency>>
+artifact go <<noDependency>>
 artifact interactions <<dependencies>>
 artifact knownDrugs <<dependencies>>
 artifact mousePhenotypes <<dependencies>>

--- a/documentation/etl_dp_dependencies.puml
+++ b/documentation/etl_dp_dependencies.puml
@@ -10,6 +10,7 @@ artifact drug
 artifact eco
 artifact evidence
 artifact expression
+artifact go
 artifact interactions
 artifact knownDrugs
 artifact mousePhenotypes

--- a/elasticsearch/load_all.sh
+++ b/elasticsearch/load_all.sh
@@ -7,23 +7,24 @@ export INDEX_SETTINGS=${ETL_INDEX_SETTINGS:-"index_settings.json"}
 # default ES endpoint
 export ES=${ETL_ES:-"http://localhost:9200"}
 
-./load_targets.sh
+./load_cancerbiomarker.sh
 ./load_diseases.sh
 ./load_disease_hpo.sh
-./load_hpo.sh
 ./load_drugs.sh
 ./load_eco.sh
-./load_so.sh
-./load_expression.sh
-./load_mp.sh
-./load_cancerbiomarker.sh
-./load_reactome.sh
-./load_openfda_faers.sh
-./load_otars.sh
-./load_evidences_aotf.sh
 ./load_evidences.sh
+./load_evidences_aotf.sh
+./load_expression.sh
+./load_hpo.sh
 ./load_interaction.sh
 ./load_interaction_evidence.sh
+./load_mp.sh
+./load_openfda_faers.sh
+./load_otars.sh
+./load_reactome.sh
+./load_so.sh
+./load_targets.sh
+
 echo "INDEX_SETTINGS different"
-./load_search.sh
 ./load_known_drugs.sh
+./load_search.sh

--- a/elasticsearch/load_go.sh
+++ b/elasticsearch/load_go.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export INDEX_NAME="go"
+export INPUT="${PREFIX}/go"
+export ID="id"
+
+./load_jsons.sh

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -19,6 +19,7 @@ common {
     "expression",
     "mousePhenotypes",
     "evidence",
+    "go",
     "association",
     "associationOTF",
     "drug",
@@ -104,12 +105,12 @@ interactions {
     ]
   }
   humanmapping {
-   format = "csv"
-   path = ${common.input}"/annotation-files/interactions/HUMAN_9606_idmapping.dat.gz"
-   options = [
-     {k: "sep", v: "\\t"},
-     {k: "header", v: "false"}
-   ]
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/HUMAN_9606_idmapping.dat.gz"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"}
+    ]
   }
   ensproteins {
     format = "csv"
@@ -125,12 +126,12 @@ interactions {
     path = ${common.input}"/annotation-files/interactions/intact-interactors-2021-06-07.json"
   }
   strings {
-     format = "csv"
-     path = ${common.input}"/annotation-files/interactions/9606.protein.links.full_w_homology.v11.0.txt.gz"
-     options = [
-       {k: "sep", v: " "},
-       {k: "header", v: "true"}
-     ]
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/9606.protein.links.full_w_homology.v11.0.txt.gz"
+    options = [
+      {k: "sep", v: " "},
+      {k: "header", v: "true"}
+    ]
   }
   outputs = {
     interactions {
@@ -700,8 +701,8 @@ evidences {
       datatype-id: "genetic_association",
       unique-fields: [
         "diseaseFromSourceId"
-     ],
-     score-expr: "element_at(map('Assessed', 1.0,'Not yet assessed', 0.5), confidence)"
+      ],
+      score-expr: "element_at(map('Assessed', 1.0,'Not yet assessed', 0.5), confidence)"
     },
     {
       id: "phenodigm",
@@ -838,6 +839,17 @@ evidences {
   ]
 }
 
+gene-ontology {
+  go-input = {
+    format = "csv"
+    path = ${common.input}"/annotation-files/go/go.obo"
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/go"
+
+  }
+}
 mouse-phenotypes {
   mp-classes {
     format = "json"

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -46,6 +46,9 @@ object ETL extends LazyLogging {
       case "eco" =>
         logger.info("run step eco")
         Eco()
+      case "go" =>
+        logger.info("run step go")
+        Go()
       case "interactions" =>
         logger.info("run step interactions")
         Interactions()

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -151,6 +151,8 @@ object Configuration extends LazyLogging {
 
   case class KnownDrugsSection(inputs: KnownDrugsInputsSection, output: IOResourceConfig)
 
+  case class GeneOntologySection(goInput: IOResourceConfig, output: IOResourceConfig)
+
   case class MousePhenotypes(mpClasses: IOResourceConfig,
                              mpReports: IOResourceConfig,
                              mpOrthology: IOResourceConfig,
@@ -222,6 +224,7 @@ object Configuration extends LazyLogging {
       disease: DiseaseSection,
       interactions: InteractionsSection,
       knownDrugs: KnownDrugsSection,
+      geneOntology: GeneOntologySection,
       search: SearchSection,
       aotf: AOTFSection,
       target: Target,

--- a/src/main/scala/io/opentargets/etl/backend/Go.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Go.scala
@@ -1,0 +1,40 @@
+package io.opentargets.etl.backend
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.spark.{IOResource, IOResourceConfig, IoHelpers}
+import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import io.opentargets.etl.preprocess.go.GoConverter
+import org.apache.spark.sql.functions.{col, desc, when}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+import scala.jdk.CollectionConverters.asScalaIteratorConverter
+
+object Go extends LazyLogging {
+  def apply()(implicit context: ETLSessionContext): IOResources = {
+    implicit val ss: SparkSession = context.sparkSession
+
+    logger.info("Executing Gene Ontology step.")
+
+    logger.debug("Reading GO inputs")
+    val inputs = Map("go" -> getGoDataFrame(context.configuration.geneOntology.goInput))
+
+    logger.debug("Processing Gene Ontology")
+    val goDF = inputs("go").data
+
+    logger.debug("Writing Gene Ontology outputs")
+    val dataframesToSave: IOResources = Map(
+      "go" -> IOResource(goDF, context.configuration.geneOntology.output)
+    )
+
+    IoHelpers.writeTo(dataframesToSave)
+
+  }
+
+  def getGoDataFrame(io: IOResourceConfig)(implicit ss: SparkSession): IOResource = {
+    import ss.implicits._
+    val path: java.util.Iterator[String] = ss.read.textFile(io.path).toLocalIterator()
+    val data = GoConverter.convertFileToGo(path.asScala)
+    IOResource(data.toDF(), io)
+  }
+
+}

--- a/src/main/scala/io/opentargets/etl/preprocess/go/GoConverter.scala
+++ b/src/main/scala/io/opentargets/etl/preprocess/go/GoConverter.scala
@@ -1,15 +1,12 @@
 package io.opentargets.etl.preprocess.go
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 case class Go(id: String, name: String)
 
 object GoConverter {
-
-  private val startEntry = (line: String) => line.startsWith("[Term]")
-  private val endEntry = (line: String) => line.isEmpty
-  private val excludedEntry = (line: String) => line.startsWith("[Typedef]")
+  private val startEntry = (line: String) => line.trim.startsWith("[Term]")
+  private val endEntry = (line: String) => line.trim.nonEmpty
   private val separator = ":"
 
   /**
@@ -25,42 +22,24 @@ object GoConverter {
     */
   def convertFileToGo(file: Iterator[String], fields: Set[String] = Set("id", "name")): Seq[Go] = {
     @tailrec
-    def getSingleEntry(acc: Seq[String] = Seq.empty[String]): Seq[String] = {
-      if (file.hasNext) {
-        val line = file.next()
-        if (endEntry(line)) acc
-        else if (excludedEntry(line)) {
-          scrollToNext()
-          getSingleEntry()
-        } else if (startEntry(line)) getSingleEntry(acc)
-        else getSingleEntry(line +: acc)
-      } else acc
+    def go(lines: Iterator[String], entries: Seq[Go]): Seq[Go] = {
+      lines.hasNext match {
+        case true =>
+          val entryIt = lines.dropWhile(startEntry)
+          val vec = entryIt
+            .takeWhile(endEntry)
+            .map(_.split(separator, 2).map(_.trim))
+            .withFilter(el => fields.contains(el.head))
+            .map(_.tail.head)
+            .toList
+          vec match {
+            case id :: name :: Nil if id.startsWith("GO") => go(lines, entries :+ Go(id, name))
+            case _                                        => go(lines, entries)
+          }
+        case false => entries
+      }
     }
 
-    @tailrec
-    def go(acc: Seq[Go] = List.empty): Seq[Go] = {
-      val entry = getSingleEntry()
-      if (entry.nonEmpty) {
-        val map: mutable.Map[String, String] = scala.collection.mutable.Map()
-        for (line <- entry) {
-          val kv = line.split(separator, 2)
-          val key = kv.head
-          if (fields.contains(key)) map(key) = kv.tail.head
-        }
-        val goEntry = Go(map("id").trim, map("name").trim)
-
-        if (file.hasNext) go(goEntry +: acc) else goEntry +: acc
-      } else acc
-
-    }
-
-    // scroll to start
-    @tailrec
-    def scrollToNext(): Unit = {
-      if (file.hasNext && !startEntry(file.next())) scrollToNext()
-    }
-
-    scrollToNext()
-    go()
+    go(file, Seq.empty[Go])
   }
 }

--- a/src/main/scala/io/opentargets/etl/preprocess/go/GoConverter.scala
+++ b/src/main/scala/io/opentargets/etl/preprocess/go/GoConverter.scala
@@ -1,0 +1,66 @@
+package io.opentargets.etl.preprocess.go
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+case class Go(id: String, name: String)
+
+object GoConverter {
+
+  private val startEntry = (line: String) => line.startsWith("[Term]")
+  private val endEntry = (line: String) => line.isEmpty
+  private val excludedEntry = (line: String) => line.startsWith("[Typedef]")
+  private val separator = ":"
+
+  /**
+    *
+    * @param file input file in obo format available from [[http://geneontology.org/docs/download-ontology/#go_obo_and_owl here]]
+    *             The file is separated into entries which start with [Term] and end with a blank line.
+    *
+    *             There are a large number of fields available as specified in the [[http://owlcollab.github.io/oboformat/doc/obo-syntax documentation]].
+    *             Fields are key-value pairs separated by a colon.
+    *
+    *             This method only extracts the id and name field.
+    * @return
+    */
+  def convertFileToGo(file: Iterator[String], fields: Set[String] = Set("id", "name")): Seq[Go] = {
+    @tailrec
+    def getSingleEntry(acc: Seq[String] = Seq.empty[String]): Seq[String] = {
+      if (file.hasNext) {
+        val line = file.next()
+        if (endEntry(line)) acc
+        else if (excludedEntry(line)) {
+          scrollToNext()
+          getSingleEntry()
+        } else if (startEntry(line)) getSingleEntry(acc)
+        else getSingleEntry(line +: acc)
+      } else acc
+    }
+
+    @tailrec
+    def go(acc: Seq[Go] = List.empty): Seq[Go] = {
+      val entry = getSingleEntry()
+      if (entry.nonEmpty) {
+        val map: mutable.Map[String, String] = scala.collection.mutable.Map()
+        for (line <- entry) {
+          val kv = line.split(separator, 2)
+          val key = kv.head
+          if (fields.contains(key)) map(key) = kv.tail.head
+        }
+        val goEntry = Go(map("id").trim, map("name").trim)
+
+        if (file.hasNext) go(goEntry +: acc) else goEntry +: acc
+      } else acc
+
+    }
+
+    // scroll to start
+    @tailrec
+    def scrollToNext(): Unit = {
+      if (file.hasNext && !startEntry(file.next())) scrollToNext()
+    }
+
+    scrollToNext()
+    go()
+  }
+}

--- a/src/test/scala/io/opentargets/etl/preprocess/GoConverterTest.scala
+++ b/src/test/scala/io/opentargets/etl/preprocess/GoConverterTest.scala
@@ -1,0 +1,53 @@
+package io.opentargets.etl.preprocess
+
+import io.opentargets.etl.preprocess.GoConverterTest.testInput
+import io.opentargets.etl.preprocess.go.GoConverter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+object GoConverterTest {
+
+  val testInput: Seq[String] =
+    """
+      |property_value: http://purl.org/dc/elements/1.1/title "Gene Ontology" xsd:string
+      |property_value: http://purl.org/dc/terms/license http://creativecommons.org/licenses/by/4.0/
+      |property_value: owl:versionInfo "2021-07-02" xsd:string
+      |
+      |[Term]
+      |id: GO:0000001
+      |name: mitochondrion inheritance
+      |namespace: biological_process
+      |def: "The distribution of mitochondria, including the mitochondrial genome, into daughter cells after mitosis or meiosis, mediated by interactions between mitochondria and the cytoskeleton." [GOC:mcc, PMID:10873824, PMID:11389764]
+      |synonym: "mitochondrial inheritance" EXACT []
+      |is_a: GO:0048308 ! organelle inheritance
+      |is_a: GO:0048311 ! mitochondrion distribution
+      |
+      |[Term]
+      |id: GO:0000002
+      |name: mitochondrial genome maintenance
+      |namespace: biological_process
+      |def: "The maintenance of the structure and integrity of the mitochondrial genome; includes replication and segregation of the mitochondrial chromosome." [GOC:ai, GOC:vw]
+      |is_a: GO:0007005 ! mitochondrion organization
+      |
+      |[Typedef]
+      |id: term_tracker_item
+      |name: term tracker item
+      |namespace: external
+      |xref: IAO:0000233
+      |is_metadata_tag: true
+      |is_class_level: true
+      |
+      |""".stripMargin.split("\n")
+}
+
+class GoConverterTest extends AnyFlatSpec with Matchers {
+  "Raw obo file" should "be parsed into a collection of GO objects" in {
+    // when
+    val results = GoConverter.convertFileToGo(testInput.toIterator)
+
+    // then
+    results.size should be(2)
+    results.head.id should be("GO:0000001")
+    results.head.name should be("mitochondrion inheritance")
+  }
+}


### PR DESCRIPTION
Add new index for gene ontology so the FE can query the API for this data instead of an external service. 

The input file is something called `.obo` which is effectively a flat file which doesn't work well with Spark. It's relatively small (results in about 40k records) so can be quickly processed with one pass in native Scala, similar to what is happening with Uniprot. 

I've also alphabetised the entries in `load_all.sh` to make it easier to find things. :)