### PR TITLE
Add Target tractability 'false' entries.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Tractability.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Tractability.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 case class TractabilityWithId(ensemblGeneId: String, tractability: Array[Tractability])
 
-case class Tractability(modality: String, id: String)
+case class Tractability(modality: String, value: Boolean, id: String)
 
 object Tractability extends LazyLogging {
 
@@ -33,11 +33,6 @@ object Tractability extends LazyLogging {
     columnsAsTractabilityStructDF
       .select(col(gid).as("ensemblGeneId"),
               array(dataColumns.head, dataColumns.tail: _*).as("tractability"))
-      .select(col("ensemblGeneId"), explode(col("tractability")) as "tractability")
-      .filter("tractability.value")
-      .drop("value")
-      .groupBy("ensemblGeneId")
-      .agg(collect_set("tractability") as "tractability")
       .as[TractabilityWithId]
 
   }


### PR DESCRIPTION
Reverting commit 5c710d3. Including false is necessary so we know if the item has been examined with a negative result, or not examined at all.

Resolves opentargets/platform#1672