### PR TITLE
Explicitly run load_drugs.sh with bash

### DIFF
--- a/elasticsearch/load_drugs.sh
+++ b/elasticsearch/load_drugs.sh
@@ -1,4 +1,4 @@
-#cat "$1" | elasticsearch_loader --es-host "http://localhost:9200" --index-settings-file "index_settings.json" --bulk-size 5000 --index drugs --type drug --id-field id json --json-lines -
+#!/bin/bash
 
 subindexes=('molecule' 'mechanismOfAction' 'indication' 'drugWarnings')
 subindexesnames=('drug' 'mechanism_of_action' 'indication' 'drug_warnings')


### PR DESCRIPTION
The file uses bash-specific array syntax and crashes with a syntax error
if parsed as a plain POSIX-standard shell script by other shells.