### PR TITLE
Update target orthology: low confidence, paralogs.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Ortholog.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Ortholog.scala
@@ -18,11 +18,10 @@ object Ortholog extends LazyLogging {
     * @param targetSpecies    List of whitelisted species taken from the configuration file.
     * @return
     */
-  def apply(
-      homologyDict: DataFrame,
-      codingProteins: DataFrame,
-      homologyGeneDict: DataFrame,
-      targetSpecies: List[String])(implicit sparkSession: SparkSession): Dataset[LinkedOrtholog] = {
+  def apply(homologyDict: DataFrame,
+            codingProteins: DataFrame,
+            homologyGeneDict: DataFrame,
+            targetSpecies: List[String])(implicit sparkSession: SparkSession): Dataset[Ortholog] = {
     import sparkSession.implicits._
     logger.info("Processing homologs.")
 
@@ -39,38 +38,33 @@ object Ortholog extends LazyLogging {
         .select(col("a")(0) as "homology_gene_stable_id", col("a")(1) as "targetGeneSymbol")
 
     val homoDF = codingProteins
-      .filter("is_high_confidence = 1")
       .join(homoDict, col("homology_species") === homoDict("speciesName"))
-      .join(homoGeneDictDf, Seq("homology_gene_stable_id"))
+      .join(homoGeneDictDf, Seq("homology_gene_stable_id"), "left_outer")
       .select(
         col("gene_stable_id").as("id"),
         col("taxonomy_id").as("speciesId"),
         col("name").as("speciesName"),
         col("homology_type").as("homologyType"),
         col("homology_gene_stable_id").as("targetGeneId"),
+        col("is_high_confidence").as("isHighConfidence"),
         col("targetGeneSymbol"),
         col("identity").cast(DoubleType).as("queryPercentageIdentity"),
         col("homology_identity")
           .cast(DoubleType)
           .as("targetPercentageIdentity")
       )
+      .as[Ortholog]
 
-    val groupedById = nest(homoDF, homoDF.columns.filter(_ != "id").toList, "homologues")
-      .withColumnRenamed("id", "humanGeneId")
-      .groupBy("humanGeneId")
-      .agg(collect_list("homologues") as "homologues")
-
-    groupedById.as[LinkedOrtholog]
+    homoDF
   }
 
 }
-
-case class LinkedOrtholog(humanGeneId: String, homologues: Array[Ortholog])
 
 case class Ortholog(speciesId: String,
                     speciesName: String,
                     homologyType: String,
                     targetGeneId: String,
                     targetGeneSymbol: String,
+                    isHighConfidence: String,
                     queryPercentageIdentity: Double,
                     targetPercentageIdentity: Double)


### PR DESCRIPTION
- Updated to include low-confidence entries
- Moved linking to `Target.scala` so we can get the approved name for paralogues.

Resolves to opentargets/platform#1699