### PR TITLE
Config refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ cat 20.04_gene-data.json | jq -r '{"id":.id,"phenotypes": [.mouse_phenotypes[]?]
 
 Copy the file in google storage or specific path
 
-### Load with custom configuration
+### Configuration
 
-Add to your run either commandline or sbt task Intellij IDEA `-Dconfig.file=application.conf` and it will load the
-configuration from your `./` path or project root. Missing fields will be resolved with `reference.conf`.
+There is a directory called `configuration` which versions all the release configuration files. To repeat a release use
+the appropriate configuration file.
+
+Add to your run either commandline or sbt task Intellij IDEA `-Dconfig.file=./configuration/<year>/<release>. conf`
+and it will run with appropriate configuration. Missing fields will be resolved with `reference.conf`.
 
 The most common configuration changes you will need to make are pointing towards the correct input files. To load files
 we use a structure:

--- a/README.md
+++ b/README.md
@@ -22,28 +22,6 @@ Either Java 8 or 11 can be used to build and run the project, but if you intend 
 _Dataproc_ you must use Java 8. To avoid this problem altogether, do not use native Java methods unless strictly
 necessary.
 
-### Generate the indices dump from ES7
-
-You will need to either connect to a machine containing the ES or forward the ssh port from it
-
-```sh
-elasticdump --input=http://localhost:9200/<indexyouneed> \
-    --output=<indexyouneed>.json \
-    --type=data  \
-    --limit 10000 \
-    --sourceOnly
-```
-
-### Mouse Phenotype input for ETL (deprecated as of 21.06 release!)
-
-Generate MousePhenotypes input file
-
-```sh
-cat 20.04_gene-data.json | jq -r '{"id":.id,"phenotypes": [.mouse_phenotypes[]?] }|@json' > mousephenotype.json
-```
-
-Copy the file in google storage or specific path
-
 ### Configuration
 
 There is a directory called `configuration` which versions all the release configuration files. To repeat a release use
@@ -178,47 +156,11 @@ common {
 }
 ```
 
-### Adding ETL outputs to ElasticSearch
-
-The `elasticsearch` directory in the project root folder includes utility scripts to load the outputs of the ETL into
-a preconfigured ElasticSearch instance. 
-
-#### Requirements
-
-1. Python utility `elasticsearch_loader` must be installed and on your `PATH`
-2. An open port of the ES instance must be forwarded to your local machine and execute the relevant script.
-
-    ```
-    gcloud beta compute ssh --zone "europe-west1-d" "es7-20-09" --project "open-targets-eu-dev" -- -L 9200:localhost:9200
-    ```  
-
-3. Update the `env.sh` script:
-    - `PREFIX` refers to the path to the data to be loaded into Elasticsearch
-    - `ES` is the url of Elasticsearch
-    - `INDEX_SETTINGS` is the index configuration file. Typically this will be the `index_settings.json` file provided
-      in the _elasticsearch_ directory.
-
-4. Export the necessary environment variables by running `source [path to file]env.sh`
-4. Run scripts relevant to the index you wish to create, or `load_all.sh` to load all of them.
-
 ## Step dependencies
-
-As of June 2021 some steps of the ETL maintain dependencies on the old Data Pipeline which is being progressively
-deprecated.
 
 Considering only the inputs/outputs of the ETL there are component diagrams available in the 'documentation'
 directory. _etl\_current_ shows the relationships between steps in the ETL. _etl\_current\_full_ shows those
 relationships at a more granular level, where inputs and outputs are specifically specified.
-
-_etl\_dp\_dependencies_ shows similar relationships, but often includes dependencies which result from the data
-pipeline. This document will be removed once the deprecation of the data pipeline is complete.
-
-The majority of the ETL was written to process data which has been prepared by the data pipeline for subsequent
-processing. It is intended that this pipeline will be deprecated; because of this some steps do not require inputs from
-the data pipeline to function correctly. These include:
-
-- Drug
-- Target
 
 ## Step notes
 
@@ -231,7 +173,6 @@ not 'drugs'. We define a drug to be any molecule that meets one or more of the f
  - The ChEMBL ID can be mapped to a DrugBank ID.  
  
 To run the `Drug` step use the example command under `Create a fat JAR` with `drug` as the step name. 
- 
 
 ### Baseline Expression
 The primary input sources of the baseline expression dataset are 
@@ -369,28 +310,18 @@ The input is a flat file which does not lend itself to columnar processing so it
 more complicated logic becomes required this should be ported. There is also to option of querying the EBI API but this
 is quite slow and results in a moderately large dataset which we don't otherwise need.
 
-### Mouse Phenotypes
-
-#### Inputs
-
-| Input | Source | Notes |
-| --- | --- | --- |
-| mp-classes | PIS | This is preprocessed by PIS using a project `opentargets-ontologyutils` to extract needed data from an OWL file in jsonl format. |
-| mp-report | PIS | |
-| mp-orthology | PIS | |
-| mp-categories | Static | This file was a hard-coded map in the deprecated data-pipeline. |
-| target | ETL | Output of target step of ETL | 
-
 ### Target
 
-These notes refer to the Target step as rewritten in March 2021. If attempting to debug datasets completed before
-release 20.XX consult commits preceeding XXXXXX.
+Generates an index of genes, each uniquely identified by an EnsemblID number. There are approximately 61000 genes
+available.
 
 #### Configuration
 
 - `hgnc-orthology-species` lists the species to include in Target orthologues. The order of this configuration list is
   __significant__ as it is used to determine the order in which entries appear in the front-end. Items earlier in the
-  list are more closely related to homo sapiens than items further down the list.
+  list are more closely related to homo sapiens than items further down the list. This is used to select which species
+  will be included in Target > Homologues. If you want to add a species to this list you must also update Platform Input
+  Support to retrieve that species' gene data.
 
 #### Inputs
 
@@ -466,12 +397,8 @@ the data. Options for parsing the inputs should not need to be updated.
           as __the spreadsheet should no longer be used__. If the underlying data changes it should be modified in the
           json/parquet files.
 
-#### Homology species whitelist
-
-This is used to select which species will be included in Target > Homologues. If you want to add a species to this list
-you must also update Platform Input Support to retrieve that species' gene data.
-
 ### OpenFDA FAERS DB
+
 The openFDA drug adverse event API returns data that has been collected from the FDA Adverse Event Reporting System (FAERS),
 a database that contains information on adverse event and medication error reports submitted to FDA.
 
@@ -496,83 +423,24 @@ a database that contains information on adverse event and medication error repor
 {"chembl_id":"CHEMBL1231","event":"cardiac output decreased","meddraCode": ..., "count":1,"llr":8.392140045623442,"critval":4.4247991585588675}
 {"chembl_id":"CHEMBL1231","event":"cardiovascular insufficiency","meddraCode": ..., "count":1,"llr":7.699049533524681,"critval":4.4247991585588675}
 ```
+
 Notice that the JSON output is actually JSONL. Each line is a single result object.
 
 #### Configuration
-The base configuration is found under `src/main/resources/reference.conf`, `openfda` section.
 
-```scala
-openfda {
-    // NOTE - Each step seems to have a commong baseline path that should be refactored
-    step-root-input-path = ${common.input}"/fda"
-    step-root-output-path = ${common.output}"/fda"
-    // Source data
-    chembl-drugs {
-        format = "json"
-        path = ${drug.outputs.drug.path}"/*.json"
-    }
-    fda-data {
-        format = "json"
-        path = ${openfda.step-root-input-path}"/*.jsonl"
-    }
-    blacklisted-events {
-        format = "csv"
-        path = ${openfda.step-root-input-path}"/blacklisted_events.txt"
-        options = [
-            {k: "sep", v: "\\t"},
-            {k: "ignoreLeadingWhiteSpace", v: "true"},
-            {k: "ignoreTrailingWhiteSpace", v: "true"}
-        ]
-    }
-    meddra {
-        meddra-preferred-terms {
-            format = "csv"
-            // Change this to whatever location the data is sitting on
-            path = ${openfda.step-root-input-path}"/meddra/MedAscii/pt.asc"
-        }
-        meddra-low-level-terms {
-            format = "csv"
-            // Change this to whatever location the data is sitting on
-            path = ${openfda.step-root-input-path}"/meddra/MedAscii/llt.asc"
-        }
-    }
-    meddra-preferred-terms-cols = ["pt_code", "pt_name"]
-    meddra-low-level-terms-cols = ["llt_code", "llt_name"]
-    montecarlo {
-        permutations: 100
-        percentile: 0.95
-    }
-    sampling {
-        size = 0.1
-        enabled = false
-    }
-    outputs = {
-        fda-unfiltered {
-            format = "parquet"
-            path = ${openfda.step-root-output-path}"/unfiltered"
-        }
-        fda-results {
-            format = "parquet"
-            path = ${openfda.step-root-output-path}"/results"
-        }
-        sampling {
-            format = "parquet"
-            path = ${openfda.step-root-output-path}"/sample"
-        }
-    }
-```
+The base configuration is under `src/main/resources/reference.conf`, `openfda` section.
 
-#### CHEMBL Drugs
+##### CHEMBL Drugs
 Refers to the `drug` output this pipeline's drug step.
 
-#### OpenFDA FAERS Data
+##### OpenFDA FAERS Data
 This section refers to the path where the OpenFDA FAERS DB dump can be found, for processing.
 
-#### Blacklisted Events
+##### Blacklisted Events
 Path to the file where to find the list of events that need to be removed from the events in OpenFDA FAERS data, as described above.
 This list is manually curated.
 
-#### Meddra (optional)
+##### Meddra (optional)
 This pipeline uses an _optional_ subset of data from the [Medical Dictionary for Regulatory Activities](https://www.meddra.org)
 to link the adverse event terms used by the FDA back to their standardised names.
 
@@ -585,16 +453,16 @@ data it must be provided on an optional basis for users who do not have this dat
 #### Montecarlo
 Specify the number of permutations and the relevance percentile threshhold.
 
-#### Sampling
+##### Sampling
 This subsection configures the sampling output from this ETL step.
 
-#### Outputs
+##### Outputs
 ETL Step outputs.
 
-##### Unfiltered OpenFDA
+###### Unfiltered OpenFDA
 This is the OpenFDA FAERS data just before running Montecarlo on it, with or without (depending on whether it was provided) Meddra information.
 
-##### OpenFDA Processing Results
+###### OpenFDA Processing Results
 This is the result data from this ETL step.
 
 ##### Sampling

--- a/configuration/2021/21_09.conf
+++ b/configuration/2021/21_09.conf
@@ -1,0 +1,1092 @@
+spark-uri = null
+
+spark-settings {
+  // Specifies the behavior when data or table already exists. Options include:
+  //   overwrite: overwrite the existing data.
+  //   append: append the data.
+  //   ignore: ignore the operation (i.e. no-op).
+  //   error or errorifexists: default option, throw an exception at runtime.
+  // Taken from `DataFrameWrite.scala` scaladoc.
+  write-mode = "error"
+}
+common {
+  default-steps = [
+    "reactome",
+    "disease",
+    "target",
+    "eco",
+    "expression",
+    "mousePhenotypes",
+    "evidence",
+    "go",
+    "association",
+    "associationOTF",
+    "drug",
+    "knownDrugs",
+    "search",
+    "ebisearch",
+    "interactions",
+    "fda"
+  ]
+  output-format = "parquet"
+  output = "gs://open-targets-pre-data-releases/21.06.5/output/etl/parquet"
+  output = ${?OT_ETL_OUTPUT}
+
+  metadata {
+    format = "json"
+    path = ${common.output}"/metadata/"
+  }
+
+  input = "gs://open-targets-pre-data-releases/21.06.5/input"
+
+  inputs {
+    eco {
+      format = "json"
+      path = "gs://open-targets-pre-data-releases/21.06.5/input/datapipeline-dump/21.06_eco-data.json"
+    }
+  }
+}
+
+reactome {
+  inputs {
+    pathways {
+      format = "csv"
+      path = ${common.input}"/annotation-files/ReactomePathways-2021-06-18.txt"
+      options = [
+        {k: "sep", v: "\\t"},
+        {k: "header", v: "false"}
+        {k: "inferSchema", v: "true"}
+      ]
+    }
+    relations {
+      format = "csv"
+      path = ${common.input}"/annotation-files/ReactomePathwaysRelation-2021-06-18.txt"
+      options = [
+        {k: "sep", v: "\\t"},
+        {k: "header", v: "false"}
+        {k: "inferSchema", v: "true"}
+      ]
+    }
+  }
+  output = {
+    format = ${common.output-format}
+    path = ${common.output}"/reactome"
+  }
+}
+
+expression {
+  rna {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_counts-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  binned {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_binned-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  zscore {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_zscore_binned-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  exprhierarchy {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/expression_hierarchy_curation-2021-08-09.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  efomap {
+    format = "json"
+    path = ${common.input}"/annotation-files/hpa/map_with_efos-2021-08-09.json"
+  }
+  tissues {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/normal_tissue-2021-08-09.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  output = {
+    format = ${common.output-format}
+    path = ${common.output}"/baselineExpression"
+  }
+}
+
+interactions {
+  scorethreshold = 0
+  target-etl {
+    format = ${common.output-format}
+    path = ${common.output}"/targets"
+  }
+  rnacentral {
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/rna_central_ensembl.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"}
+    ]
+  }
+  humanmapping {
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/HUMAN_9606_idmapping.dat.gz"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"}
+    ]
+  }
+  ensproteins {
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/Homo_sapiens.GRCh38.chr.gtf.gz"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"},
+      {k: "comment", v: "#"}
+    ]
+  }
+  intact {
+    format = "json"
+    path = ${common.input}"/annotation-files/interactions/intact-interactors-2021-06-07.json"
+  }
+  strings {
+    format = "csv"
+    path = ${common.input}"/annotation-files/interactions/9606.protein.links.full_w_homology.v11.0.txt.gz"
+    options = [
+      {k: "sep", v: " "},
+      {k: "header", v: "true"}
+    ]
+  }
+  outputs = {
+    interactions {
+      format = ${common.output-format}
+      path = ${common.output}"/interaction"
+    }
+    interactions-evidence {
+      format = ${common.output-format}
+      path = ${common.output}"/interactionEvidence"
+    }
+    interactions-unmatched {
+      format = ${common.output-format}
+      path = ${common.output}"/interactionUnmatched"
+    }
+  }
+}
+
+target {
+  jarrod-dev-data = "gs://ot-team/jarrod/target-inputs/"
+  input {
+    chembl = ${drug.chembl-target}
+    chemical-probes = {
+      format = "json"
+      path = "gs://otar001-core/ProbeMiner/annotation/chemicalprobes-2021-08-18.json"
+    }
+    ensembl {
+      format = "json"
+      path = ${jarrod-dev-data}"ensembl/homo_sapiens_104.jsonl"
+    }
+    genetic-constraints = {
+      format = "csv"
+      path = ${jarrod-dev-data}"gnomad/gnomad_lof.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+        {k: "nullValue", v: "NA"}
+      ]
+    }
+    gene-ontology {
+      format = "csv"
+      path = ${jarrod-dev-data}"go/goa_human.gaf.gz"
+      options = [
+        {k: "sep", v: "\\t"},
+        {k: "comment", v: "!"} // remove all metadata lines beginning with !
+      ]
+    }
+    gene-ontology-rna {
+      format = "csv"
+      path = ${jarrod-dev-data}"go/goa_human_rna.gaf.gz"
+      options = [
+        {k: "sep", v: "\\t"},
+        {k: "comment", v: "!"} // remove all metadata lines beginning with !
+      ]
+    }
+    gene-ontology-rna-lookup {
+      format = "csv"
+      path = ${jarrod-dev-data}"go/ensembl.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+      ]
+    }
+    gene-ontology-eco {
+      format = "csv"
+      path = ${jarrod-dev-data}"go/goa_human.gpa.gz"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "comment", v: "!"}
+      ]
+    }
+    hallmarks {
+      format = "csv"
+      path = ${jarrod-dev-data}"hallmarks/cosmic-hallmarks-*.tsv.gz"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    hgnc {
+      format = "json"
+      path = "gs://open-targets-data-releases/21.06/input/annotation-files/hgnc_complete_set-2021-06-18.json"
+    },
+    homology-dictionary {
+      format = "csv"
+      path = ${jarrod-dev-data}"homologue/species_EnsemblVertebrates.txt"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    homology-coding-proteins {
+      format = "csv"
+      path = ${jarrod-dev-data}"homologue/104/*.tsv.gz"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    homology-gene-dictionary {
+      format = "csv"
+      path = ${jarrod-dev-data}"homology_104_id_name.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+      ]
+    }
+    hpa {
+      format = "csv"
+      path = ${jarrod-dev-data}"hpa/subcellular_location.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    ncbi {
+      format = "csv"
+      path = ${jarrod-dev-data}"/ncbi/Homo_sapiens.gene_info.gz"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    ortholog {
+      format = "csv"
+      path = ${jarrod-dev-data}"human_all_hcop_sixteen_column-2020-11-10.txt.gz"
+    },
+    ps-gene-identifier {
+      format = "csv"
+      path = ${jarrod-dev-data}"projectScores/gene_identifiers_latest.csv.gz"
+      options = [
+        {k: "header", v: true}
+      ]
+    }
+    ps-essentiality-matrix {
+      format = "csv"
+      path = ${jarrod-dev-data}"projectScores/04_binaryDepScores.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    reactome-etl = {
+      format = "parquet"
+      path = "gs://open-targets-data-releases/21.06/output/etl/parquet/reactome/*.parquet"
+    }
+    reactome-pathways = {
+      format = "csv"
+      path = ${jarrod-dev-data}"reactome/Ensembl2Reactome.txt"
+      options = [
+        {k: "sep", v: "\\t"}
+      ]
+    }
+    safety-toxicity {
+      format = "csv"
+      path = ${jarrod-dev-data}"safety/ToxCast*.tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    safety-adverse-event {
+      format = "parquet"
+      path = ${jarrod-dev-data}"safety/ae_safety/*.parquet"
+    }
+    safety-safety-risk {
+      format = "parquet"
+      path = ${jarrod-dev-data}"safety/sr_safety/*.parquet"
+    }
+    tep {
+      format = "json"
+      path = "gs://open-targets-data-releases/21.06/input/annotation-files/tep-2021-06-18.json"
+    },
+    tractability = {
+      format = "csv"
+      path = ${jarrod-dev-data}"tractability/tracta*tsv"
+      options = [
+        {k: "sep", v: "\\t"}
+        {k: "header", v: true}
+      ]
+    }
+    uniprot {
+      format = "txt"
+      path = ${jarrod-dev-data}"uniprot_reviewed_homo.txt"
+    }
+  }
+  outputs {
+    target {
+      format = ${common.output-format}
+      path = ${common.output}"/target"
+    }
+  }
+  hgnc-ortholog-species = [
+    "9606-human",
+    "9598-chimpanzee",
+    "9544-macaque",
+    "10090-mouse",
+    "10116-rat",
+    "9986-rabbit",
+    "10141-guineapig",
+    "9615-dog",
+    "9823-pig",
+    "8364-frog",
+    "7955-zebrafish",
+    "7227-fly",
+    "6239-worm",
+  ]
+}
+
+disease {
+  efo-ontology {
+    format = "json"
+    path = ${common.input}"/annotation-files/ontology/efo_json/ontology-efo-v3.31.0.jsonl"
+  }
+  hpo-ontology {
+    format = "json"
+    path = ${common.input}"/annotation-files/ontology/efo_json/ontology-hpo.jsonl"
+  }
+  mondo-ontology {
+    format = "json"
+    path = ${common.input}"/annotation-files/ontology/efo_json/ontology-mondo.jsonl"
+  }
+  hpo-phenotype {
+    format = "json"
+    path = ${common.input}"/annotation-files/ontology/efo_json/hpo-phenotypes-2021-06-18.jsonl"
+  }
+  outputs = {
+    diseases {
+      format = ${common.output-format}
+      path = ${common.output}"/diseases"
+    }
+    hpo {
+      format = ${common.output-format}
+      path = ${common.output}"/hpo"
+    }
+    disease-hpo {
+      format = ${common.output-format}
+      path = ${common.output}"/diseaseToPhenotype"
+    }
+  }
+}
+
+drug {
+  chembl-molecule {
+    format = "json"
+    path = ${common.input}"/annotation-files/chembl/chembl_28_molecule-2021-06-18.jsonl"
+  }
+  chembl-indication {
+    format = "json"
+    path = ${common.input}"/annotation-files/chembl/chembl_28_drug_indication-2021-06-18.jsonl"
+  }
+  chembl-mechanism {
+    format = "json"
+    path = ${common.input}"/annotation-files/chembl/chembl_28_mechanism-2021-06-18.jsonl"
+  }
+  chembl-target {
+    format = "json"
+    path = ${common.input}"/annotation-files/chembl/chembl_28_target-2021-06-18.jsonl"
+  }
+  chembl-warning {
+    format = "json"
+    path = ${common.input}"/annotation-files/chembl/chembl_28_drug_warning-2021-06-18.jsonl"
+  }
+  disease-etl = ${disease.outputs.diseases}
+  target-etl {
+    format = ${common.output-format}
+    path = ${common.output}"/targets"
+  }
+  evidence-etl = ${evidences.outputs.succeeded}
+  drugbank-to-chembl {
+    format = "csv"
+    path = ${common.input}"/annotation-files/chembl/drugbank/db.csv.gz"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+    ]
+  }
+  drug-extensions = [
+    {
+      extension-type = "synonym"
+      input {
+        path = "gs://ot-team/jarrod/drugbank/db.json"
+        format = "json"
+      }
+    }
+  ]
+  outputs = {
+    drug {
+      format = ${common.output-format}
+      path = ${common.output}"/molecule"
+    }
+    mechanism-of-action {
+      format = ${common.output-format}
+      path = ${common.output}"/mechanismOfAction"
+    }
+    indications {
+      format = ${common.output-format}
+      path = ${common.output}"/indication"
+    }
+    warnings {
+      format = ${common.output-format}
+      path = ${common.output}"/drugWarnings"
+    }
+  }
+}
+
+known-drugs {
+  inputs = {
+    evidences = ${evidences.outputs.succeeded}
+    diseases = ${disease.outputs.diseases}
+    targets {
+      path = ${common.output}"/targets"
+      format = ${common.output-format}
+    }
+    drugs = ${drug.outputs}
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/knownDrugsAggregated"
+  }
+}
+
+evidences {
+  outputs {
+    succeeded {
+      format = ${common.output-format}
+      path = ${common.output}"/evidence"
+      partition-by = ["sourceId"]
+    }
+    failed {
+      format = ${common.output-format}
+      path = ${common.output}"/evidenceFailed"
+      partition-by = ["sourceId"]
+    }
+  }
+
+  inputs {
+    raw-evidences {
+      format = "json"
+      path = ${common.input}"/evidence-files//*"
+    }
+    diseases {
+      format = ${common.output-format}
+      path = ${common.output}"/diseases"
+    }
+    targets {
+      format = ${common.output-format}
+      path = ${common.output}"/targets"
+    }
+  }
+
+  unique-fields = [
+    "targetId",
+    "targetFromSourceId",
+    "diseaseId",
+    "datasourceId"
+  ]
+
+  score-expr = "resourceScore"
+  datatype-id = "other"
+
+  data-sources = [
+    {
+      id: "chembl",
+      unique-fields: [
+        "drugId",
+        "urls.url"
+      ],
+      score-expr: "element_at(map(0, 0.09, 1, 0.1, 2, 0.2, 3, 0.7, 4, 1.0), clinicalPhase)"
+    },
+    {
+      id: "europepmc",
+      unique-fields: [
+        "literature"
+      ],
+      score-expr: "array_min(array(resourceScore / 100.0, 1.0))"
+    },
+    {
+      id: "eva",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "studyId",
+        "variantId"
+      ],
+      score-expr: """
+      coalesce(array_max(
+        transform(
+          clinicalSignificances,
+          x -> element_at(
+            map(
+              'association not found', 0.0,
+              'benign', 0.0,
+              'not provided', 0.0,
+              'likely benign', 0.0,
+              'conflicting interpretations of pathogenicity', 0.3,
+              'conflicting data from submitters', 0.3,
+              'other', 0.3,
+              'uncertain significance', 0.3,
+              'risk factor', 0.5,
+              'affects', 0.5,
+              'likely pathogenic', 0.7,
+              'confers sensitivity', 0.9,
+              'association', 0.9,
+              'drug response', 0.9,
+              'protective', 0.9,
+              'pathogenic', 0.9
+              ),
+            x)
+        )
+      ), 0.0) + coalesce(element_at(
+        map(
+          'practice guideline', 0.1,
+          'reviewed by expert panel', 0.07,
+          'criteria provided, multiple submitters, no conflicts', 0.05,
+          'criteria provided, conflicting interpretations', 0.02,
+          'criteria provided, single submitter', 0.02,
+          'no assertion for the individual variant', 0.0,
+          'no assertion criteria provided', 0.0,
+          'no assertion provided', 0.0
+        ),
+        confidence
+      ), 0.0)
+      """
+    },
+    {
+      id: "eva_somatic",
+      unique-fields: [
+        "studyId",
+        "variantId"
+      ],
+      score-expr: """
+      coalesce(array_max(
+        transform(
+          clinicalSignificances,
+          x -> element_at(
+            map(
+              'association not found', 0.0,
+              'benign', 0.0,
+              'not provided', 0.0,
+              'likely benign', 0.0,
+              'conflicting interpretations of pathogenicity', 0.3,
+              'other', 0.3,
+              'uncertain significance', 0.3,
+              'risk factor', 0.5,
+              'affects', 0.5,
+              'likely pathogenic', 0.7,
+              'association', 0.9,
+              'drug response', 0.9,
+              'protective', 0.9,
+              'pathogenic', 0.9
+              ),
+            x)
+        )
+      ), 0.0) + coalesce(element_at(
+        map(
+          'practice guideline', 0.1,
+          'reviewed by expert panel', 0.07,
+          'criteria provided, multiple submitters, no conflicts', 0.05,
+          'criteria provided, conflicting interpretations', 0.02,
+          'criteria provided, single submitter', 0.02,
+          'no assertion for the individual variant', 0.0,
+          'no assertion criteria provided', 0.0,
+          'no assertion provided', 0.0
+        ),
+        confidence
+      ), 0.0)
+      """
+    },
+    {
+      excluded-biotypes: [
+        "IG_C_pseudogene",
+        "IG_J_pseudogene",
+        "IG_pseudogene",
+        "IG_V_pseudogene",
+        "polymorphic_pseudogene",
+        "processed_pseudogene",
+        "pseudogene",
+        "rRNA",
+        "rRNA_pseudogene",
+        "snoRNA",
+        "snRNA",
+        "transcribed_processed_pseudogene",
+        "transcribed_unitary_pseudogene",
+        "transcribed_unprocessed_pseudogene",
+        "TR_J_pseudogene",
+        "TR_V_pseudogene",
+        "unitary_pseudogene",
+        "unprocessed_pseudogene"
+      ],
+      id: "expression_atlas",
+      unique-fields: [
+        "contrast",
+        "studyId"
+      ],
+      score-expr: "array_min(array(1.0, pvalue_linear_score_default(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))"
+    },
+    {
+      id: "gene2phenotype",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "diseaseFromSource",
+        "allelicRequirements",
+        "studyId"
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'possible', 0.25,
+          'probable', 0.5,
+          'confirmed', 1.0,
+          'both RD and IF', 1.0,
+          'child IF', 1.0
+        ),
+        confidence
+      )
+      """
+    },
+    {
+      id: "genomics_england",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "diseaseFromSource",
+        "studyId"
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'amber', 0.5,
+          'green', 1.0
+        ),
+        confidence
+      )
+      """
+    },
+    {
+      id: "intogen",
+      unique-fields: [
+        "cohortShortName"
+      ],
+      score-expr: "pvalue_linear_score(resourceScore, 0.1, 1e-10, 0.25, 1.0)"
+    },
+    {
+      id: "ot_genetics_portal",
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "studyId",
+        "variantId"
+      ],
+      score-expr: "resourceScore"
+    },
+    {
+      id: "orphanet",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "diseaseFromSourceId"
+      ],
+      score-expr: "element_at(map('Assessed', 1.0,'Not yet assessed', 0.5), confidence)"
+    },
+    {
+      id: "phenodigm",
+      unique-fields: [
+        "diseaseFromSource",
+        "biologicalModelAllelicComposition",
+        "targetInModel",
+        "biologicalModelGeneticBackground"
+      ],
+      score-expr: "resourceScore / 100"
+    },
+    {
+      id: "phewas_catalog",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "diseaseFromSource",
+        "variantRsId"
+      ],
+      score-expr: "linear_rescale(studyCases, 0.0, 8800.0, 0.0, 1.0) * pvalue_linear_score(resourceScore, 0.5, 1e-25, 0.0, 1.0)"
+    },
+    {
+      id: "crispr",
+      score-expr: "linear_rescale(resourceScore, 41.5, 100, 0.415, 1.0)",
+      unique-fields: []
+    },
+    {
+      id: "progeny",
+      unique-fields: [
+        "pathways",
+        "diseaseFromSource"
+      ],
+      score-expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
+    },
+    {
+      id: "reactome",
+      unique-fields: [
+        "variantAminoacidDescriptions",
+        "targetModulation",
+        "reactionId"
+      ],
+      score-expr: "1.0"
+    },
+    {
+      id: "slapenrich",
+      unique-fields: [
+        "pathways",
+        "diseaseFromSource"
+      ],
+      score-expr: "pvalue_linear_score(resourceScore, 1e-4, 1e-14, 0.5, 1.0)"
+    },
+    {
+      id: "sysbio",
+      unique-fields: [
+        "studyOverview",
+        "literature",
+        "pathways"
+      ],
+      score-expr: "resourceScore"
+    },
+    {
+      id: "uniprot_literature"
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "diseaseFromSource",
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'high', 1.0,
+          'medium', 0.5
+        ),
+        confidence
+      )
+      """
+
+    },
+    {
+      id: "uniprot_variants"
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "diseaseFromSource",
+        "variantRsId"
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'high', 1.0,
+          'medium', 0.5
+        ),
+        confidence
+      )
+      """
+
+    },
+    {
+      id: "clingen"
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "diseaseFromSource",
+        "studyId",
+        "allelicRequirements",
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'No Known Disease Relationship', 0.01,
+          'Refuted', 0.01,
+          'Disputed', 0.01,
+          'Limited', 0.01,
+          'Moderate', 0.5,
+          'Strong', 1.0,
+          'Definitive', 1.0
+        ),
+        confidence
+      )
+      """
+    },
+    {
+      id: "orphanet"
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "diseaseFromSourceId"
+      ],
+      score-expr: """
+      element_at(
+        map(
+          'Assessed', 1.0,
+          'Not yet assessed', 0.5
+        ),
+        confidence
+      )
+      """
+    }
+  ]
+}
+
+gene-ontology {
+  go-input = {
+    format = "csv"
+    path = ${common.input}"/annotation-files/go/go.obo"
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/go"
+
+  }
+}
+mouse-phenotypes {
+  mp-classes {
+    format = "json"
+    path = ${common.input}"/annotation-files/mp/mp-ontology*.jsonl"
+  }
+  mp-orthology {
+    format = "csv"
+    path = ${common.input}"/annotation-files/HMD_HumanPhenotype-*.rpt"
+    options = [
+      {k: "sep", v: "\\t"},
+    ]
+  }
+  mp-reports {
+    format = "csv"
+    path = ${common.input}"/annotation-files/MGI_PhenoGenoMP*.rpt"
+    options = [
+      {k: "sep", v: "\\t"},
+    ]
+  }
+  mp-categories {
+    format = "csv"
+    path = ${common.input}"/annotation-files/phenotype_categories.csv"
+    options = [
+      {k: "header", v: true},
+    ]
+  }
+  target = ${target.outputs.target}
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/mousePhenotypes"
+  }
+}
+
+associations {
+  outputs = {
+    direct-by-datatype = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByDatatypeDirect"
+    }
+    direct-by-datasource = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByDatasourceDirect"
+    }
+    direct-by-overall = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByOverallDirect"
+    }
+    indirect-by-datasource = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByDatasourceIndirect"
+    }
+    indirect-by-datatype = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByDatatypeIndirect"
+    }
+    indirect-by-overall = {
+      format = ${common.output-format}
+      path = ${common.output}"/associationByOverallIndirect"
+    }
+  }
+  inputs = {
+    evidences = ${evidences.outputs.succeeded}
+    diseases {
+      path = ${common.output}"/diseases"
+      format = ${common.output-format}
+    }
+  }
+
+  default-weight = 1.0
+  default-propagate = true
+  data-sources = [
+    {id: "europepmc", weight: 0.2, data-type = "literature", propagate = true},
+    {id: "expression_atlas", weight: 0.2, data-type = "rna_expression", propagate = false},
+    {id: "phenodigm", weight: 0.2, data-type = "animal_model", propagate = true},
+    {id: "progeny", weight: 0.5, data-type = "affected_pathway", propagate = true},
+    {id: "slapenrich", weight: 0.5, data-type = "affected_pathway", propagate = true},
+    {id: "sysbio", weight: 0.5, data-type = "affected_pathway", propagate = true},
+  ]
+}
+
+aotf {
+  outputs = {
+    clickhouse = {
+      format = ${common.output-format}
+      path = ${common.output}"/AOTFClickhouse"
+    }
+    elasticsearch = {
+      format = "json"
+      path = ${common.output}"/AOTFElasticsearch"
+    }
+  }
+
+  inputs = {
+    reactome = ${reactome.output}
+    evidences = ${evidences.outputs.succeeded}
+    diseases = ${disease.outputs.diseases}
+    targets {
+      path = ${common.output}"/targets"
+      format = ${common.output-format}
+    }
+  }
+}
+
+search {
+  inputs = {
+    evidences = ${evidences.outputs.succeeded}
+    diseases = ${disease.outputs.diseases}
+    disease-hpo = ${disease.outputs.disease-hpo}
+    hpo = ${disease.outputs.hpo}
+    targets {
+      path = ${common.output}"/targets"
+      format = ${common.output-format}
+    }
+    drugs = ${drug.outputs}
+    associations = ${associations.outputs.indirect-by-overall}
+  }
+  outputs {
+    targets {
+      format = ${common.output-format}
+      path = ${common.output}"/searchTarget"
+    }
+    diseases {
+      format = ${common.output-format}
+      path = ${common.output}"/searchDisease"
+    }
+    drugs {
+      format = ${common.output-format}
+      path = ${common.output}"/searchDrug"
+    }
+  }
+}
+
+// OpenFDA FAERS Configuration
+
+openfda {
+  // NOTE - Each step seems to have a commong baseline path that should be refactored
+  step-root-input-path = ${common.input}"/fda"
+  step-root-output-path = ${common.output}"/fda"
+  // Source data
+  chembl-drugs {
+    format = "json"
+    path = ${drug.outputs.drug.path}"/*.json"
+  }
+  fda-data {
+    format = "json"
+    path = ${openfda.step-root-input-path}"/*.jsonl"
+  }
+  blacklisted-events {
+    format = "csv"
+    path = ${openfda.step-root-input-path}"/blacklisted_events.txt"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "ignoreLeadingWhiteSpace", v: "true"},
+      {k: "ignoreTrailingWhiteSpace", v: "true"}
+    ]
+  }
+  meddra {
+    meddra-preferred-terms {
+      format = "csv"
+      // Change this to whatever location the data is sitting on
+      path = ${openfda.step-root-input-path}"/meddra/MedAscii/pt.asc"
+    }
+    meddra-low-level-terms {
+      format = "csv"
+      // Change this to whatever location the data is sitting on
+      path = ${openfda.step-root-input-path}"/meddra/MedAscii/llt.asc"
+    }
+  }
+  meddra-preferred-terms-cols = ["pt_code", "pt_name"]
+  meddra-low-level-terms-cols = ["llt_code", "llt_name"]
+  montecarlo {
+    permutations: 100
+    percentile: 0.95
+  }
+  sampling {
+    size = 0.1
+    enabled = false
+  }
+  outputs = {
+    fda-unfiltered {
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/unfiltered"
+    }
+    fda-results {
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/results"
+    }
+    sampling {
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/sample"
+    }
+  }
+
+}
+
+ebisearch {
+  disease-etl = ${disease.outputs.diseases}
+  target-etl {
+    format = ${common.output-format}
+    path = ${common.output}"/targets"
+  }
+  evidence-etl {
+    format = ${common.output-format}
+    path = ${evidences.outputs.succeeded.path}"/sourceId=ot_genetics_portal/"
+  }
+  association-etl = ${associations.outputs.direct-by-overall}
+  outputs = {
+    ebisearch-associations {
+      format = ${common.output-format}
+      path = ${common.output}"/ebisearchAssociations"
+    }
+    ebisearch-evidence {
+      format = ${common.output-format}
+      path = ${common.output}"/ebisearchEvidence"
+    }
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,7 +15,6 @@ common {
     "disease",
     "target",
     "eco",
-    "cancerBiomarkers",
     "expression",
     "mousePhenotypes",
     "evidence",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -190,19 +190,20 @@ interactions {
 }
 
 target {
+  jarrod-dev-data = "gs://ot-team/jarrod/target-inputs/"
   input {
     chembl = ${drug.chembl-target}
     chemical-probes = {
       format = "json"
-      path = ${common.input}"/annotation-files/chemical-probes/chemicalprobes-2021-08-12.json"
+      path = "gs://otar001-core/ProbeMiner/annotation/chemicalprobes-2021-08-18.json"
     }
     ensembl {
       format = "json"
-      path = ${common.input}"/annotation-files/homo_sapiens_core_104_38_genes.json.gz"
+      path = ${jarrod-dev-data}"ensembl/homo_sapiens_104.jsonl"
     }
     genetic-constraints = {
       format = "csv"
-      path = "gs://ot-snapshots/jsonl/20.06/gnomad_lof_metrics_by_gene.csv"
+      path = ${jarrod-dev-data}"gnomad/gnomad_lof.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -211,7 +212,7 @@ target {
     }
     gene-ontology {
       format = "csv"
-      path = ${common.input}"/annotation-files/goa_human.gaf.gz"
+      path = ${jarrod-dev-data}"go/goa_human.gaf.gz"
       options = [
         {k: "sep", v: "\\t"},
         {k: "comment", v: "!"} // remove all metadata lines beginning with !
@@ -219,7 +220,7 @@ target {
     }
     gene-ontology-rna {
       format = "csv"
-      path = ${common.input}"/annotation-files/goa_human_rna.gaf.gz"
+      path = ${jarrod-dev-data}"go/goa_human_rna.gaf.gz"
       options = [
         {k: "sep", v: "\\t"},
         {k: "comment", v: "!"} // remove all metadata lines beginning with !
@@ -227,14 +228,14 @@ target {
     }
     gene-ontology-rna-lookup {
       format = "csv"
-      path = ${common.input}"/annotation-files/ensembl.tsv"
+      path = ${jarrod-dev-data}"go/ensembl.tsv"
       options = [
         {k: "sep", v: "\\t"}
       ]
     }
     gene-ontology-eco {
       format = "csv"
-      path = ${common.input}"/annotation-files/goa_human.gpa.gz"
+      path = ${jarrod-dev-data}"go/goa_human.gpa.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "comment", v: "!"}
@@ -242,7 +243,7 @@ target {
     }
     hallmarks {
       format = "csv"
-      path = ${common.input}"/annotation-files/cosmic-hallmarks-*.tsv.gz"
+      path = ${jarrod-dev-data}"hallmarks/cosmic-hallmarks-*.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -250,11 +251,11 @@ target {
     }
     hgnc {
       format = "json"
-      path = ${common.input}"/annotation-files/hgnc_complete_set-2020-11-10.json"
+      path = "gs://open-targets-data-releases/21.06/input/annotation-files/hgnc_complete_set-2021-06-18.json"
     },
     homology-dictionary {
       format = "csv"
-      path = ${common.input}"/annotation-files/species_EnsemblVertebrates.txt"
+      path = ${jarrod-dev-data}"homologue/species_EnsemblVertebrates.txt"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -262,7 +263,7 @@ target {
     }
     homology-coding-proteins {
       format = "csv"
-      path = ${common.input}"/annotation-files/Compara.104.*_default.homologies.tsv.gz"
+      path = ${jarrod-dev-data}"homologue/104/*.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -270,14 +271,14 @@ target {
     }
     homology-gene-dictionary {
       format = "csv"
-      path = ${common.input}"annotation-files/104_homology_name_id.tsv"
+      path = ${jarrod-dev-data}"homology_104_id_name.tsv"
       options = [
         {k: "sep", v: "\\t"}
       ]
     }
     hpa {
       format = "csv"
-      path = ${common.input}"/annotation-files/subcellular_location.tsv"
+      path = ${jarrod-dev-data}"hpa/subcellular_location.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -285,7 +286,7 @@ target {
     }
     ncbi {
       format = "csv"
-      path = ${common.input}"/annotation-files/Homo_sapiens.gene_info.gz"
+      path = ${jarrod-dev-data}"/ncbi/Homo_sapiens.gene_info.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -293,34 +294,37 @@ target {
     }
     ortholog {
       format = "csv"
-      path = ${common.input}"/annotation-files/human_all_hcop_sixteen_column-2020-11-10.txt.gz"
+      path = ${jarrod-dev-data}"human_all_hcop_sixteen_column-2020-11-10.txt.gz"
     },
     ps-gene-identifier {
       format = "csv"
-      path = ${common.input}"/annotation-files/gene_identifiers_latest.csv.gz"
+      path = ${jarrod-dev-data}"projectScores/gene_identifiers_latest.csv.gz"
       options = [
         {k: "header", v: true}
       ]
     }
     ps-essentiality-matrix {
       format = "csv"
-      path = ${common.input}"annotation-files/04_binaryDepScores.tsv"
+      path = ${jarrod-dev-data}"projectScores/04_binaryDepScores.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
       ]
     }
-    reactome-etl = ${reactome.output}
+    reactome-etl = {
+      format = "parquet"
+      path = "gs://open-targets-data-releases/21.06/output/etl/parquet/reactome/*.parquet"
+    }
     reactome-pathways = {
       format = "csv"
-      path = ${common.input}"reactome/Ensembl2Reactome.txt"
+      path = ${jarrod-dev-data}"reactome/Ensembl2Reactome.txt"
       options = [
         {k: "sep", v: "\\t"}
       ]
     }
     safety-toxicity {
       format = "csv"
-      path = ${common.input}"safety/ToxCast_*.tsv"
+      path = ${jarrod-dev-data}"safety/ToxCast*.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -328,19 +332,19 @@ target {
     }
     safety-adverse-event {
       format = "parquet"
-      path = ${common.input}"safety/adverse-events/*.parquet"
+      path = ${jarrod-dev-data}"safety/ae_safety/*.parquet"
     }
     safety-safety-risk {
       format = "parquet"
-      path = ${common.input}"safety/safety-risk/*.parquet"
+      path = ${jarrod-dev-data}"safety/sr_safety/*.parquet"
     }
     tep {
       format = "json"
-      path = ${common.input}"annotation-files/tep-2021-06-18.json"
+      path = "gs://open-targets-data-releases/21.06/input/annotation-files/tep-2021-06-18.json"
     },
     tractability = {
       format = "csv"
-      path = "gs://ot-snapshots/otar001-core/Tractability/21.03/tractability_buckets_new_version.tsv"
+      path = ${jarrod-dev-data}"tractability/tracta*tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -348,13 +352,13 @@ target {
     }
     uniprot {
       format = "txt"
-      path = ${common.input}"annotation-files/uniprot-2020-11-10.txt.gz"
+      path = ${jarrod-dev-data}"uniprot_reviewed_homo.txt"
     }
   }
   outputs {
     target {
       format = ${common.output-format}
-      path = ${common.output}"/target-beta"
+      path = ${common.output}"/target"
     }
   }
   hgnc-ortholog-species = [

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -189,8 +189,8 @@ interactions {
   }
 }
 
+jarrod-dev-data = "gs://ot-team/jarrod/target-inputs/"
 target {
-  jarrod-dev-data = "gs://ot-team/jarrod/target-inputs/"
   input {
     chembl = ${drug.chembl-target}
     chemical-probes = {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -44,18 +44,6 @@ common {
       format = "json"
       path = "gs://open-targets-pre-data-releases/21.06.5/input/datapipeline-dump/21.06_eco-data.json"
     }
-    mousephenotypes {
-      format = "json"
-      path = "gs://open-targets-pre-data-releases/21.06.5/input/datapipeline-dump/mousephenotype.json"
-    }
-    target {
-      format = "json"
-      path = "gs://open-targets-pre-data-releases/21.06.5/input/datapipeline-dump/21.06_gene-data.json"
-    }
-    tep {
-      format = "json"
-      path = "gs://open-targets-pre-data-releases/21.06.5/input/annotation-files/tep-2021-06-18.json"
-    }
   }
 }
 

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -133,10 +133,7 @@ object Configuration extends LazyLogging {
   )
 
   case class Inputs(
-      target: InputInfo,
       eco: InputInfo,
-      tep: InputInfo,
-      mousephenotypes: InputInfo
   )
 
   case class Common(defaultSteps: Seq[String],

--- a/src/main/scala/io/opentargets/etl/backend/Target.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Target.scala
@@ -216,14 +216,14 @@ object Target extends LazyLogging {
         reactomeC.output.format,
         reactomeC.output.path
       ),
-      "target" -> IOResourceConfig(
-        common.inputs.target.format,
-        common.inputs.target.path
-      ),
-      "tep" -> IOResourceConfig(
-        common.inputs.tep.format,
-        common.inputs.tep.path
-      )
+      //      "target" -> IOResourceConfig(
+      //        common.inputs.target.format,
+      //        common.inputs.target.path
+      //      ),
+      //      "tep" -> IOResourceConfig(
+      //        common.inputs.tep.format,
+      //        common.inputs.tep.path
+      //      )
     )
 
     val inputDataFrame = IoHelpers.readFrom(mappedInputs)


### PR DESCRIPTION
Updating `reference.conf` to use current target inputs to facilitate running ETL. 

Creating a new configuration directory so we can start version control of configuration files. 