### PR TITLE
Fix Target write issue in Parquet format.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -124,7 +124,7 @@ object Safety extends LazyLogging {
           lit(null) as "tissueId",
           col("cell_short_name") as "cellLabel",
           col("cell_format") as "cellFormat",
-          lit(null) as "cellId"
+          lit("") as "cellId"
         ) as "biosample",
         trim(col("official_symbol")) as "name",
         lit("Toxcast") as "datasource",


### PR DESCRIPTION
Parquet does not support columns of `NullType`. We don't have
data yet for `cellId` in target safety as the data team has
not yet produced it. Adding an empty string coerces Spark to
update the type to `StringType`.

When the data becomes available this commit should be reverted.