### PR TITLE
fda compatible with parquet/json

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -992,8 +992,8 @@ openfda {
     step-root-output-path = ${common.output}"/fda"
     // Source data
     chembl-drugs {
-        format = "json"
-        path = ${drug.outputs.drug.path}"/*.json"
+        format = ${common.output-format}
+        path = ${drug.outputs.drug.path}
     }
     fda-data {
         format = "json"


### PR DESCRIPTION
Fixing FDA for generating parquet and jsonline output.