### PR TITLE
remove eco from the config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -38,12 +38,6 @@ common {
 
   input = "gs://open-targets-pre-data-releases/21.08.preview/input"
 
-  inputs {
-    eco {
-      format = "json"
-      path = "gs://open-targets-pre-data-releases/21.08.preview/input/datapipeline-dump/21.06_eco-data.json"
-    }
-  }
 }
 
 reactome {


### PR DESCRIPTION
It seems the inputs.eco was still in the reference.conf

Remove the eco info