### PR TITLE
Add cancer_genome_interpreter to the config file

### DIFF
--- a/configuration/2021/21_09.conf
+++ b/configuration/2021/21_09.conf
@@ -858,7 +858,18 @@ evidences {
         confidence
       )
       """
-    }
+    },
+    {
+       id: "cancer_genome_interpreter"
+       unique-fields: [
+         "biomarkerName",
+         "confidence",
+         "diseaseFromSource",
+         "drugFromSource",
+         "drugResponse"
+       ],
+       score-expr: "1.0"
+     }
   ]
 }
 
@@ -950,6 +961,7 @@ associations {
     {id: "progeny", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "slapenrich", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "sysbio", weight: 0.5, data-type = "affected_pathway", propagate = true},
+    {id: "cancer_genome_interpreter", weight: 0.5, data-type = "affected_pathway", propagate = true},
   ]
 }
 

--- a/configuration/2021/21_09.conf
+++ b/configuration/2021/21_09.conf
@@ -844,22 +844,6 @@ evidences {
       """
     },
     {
-      id: "orphanet"
-      datatype-id: "genetic_association"
-      unique-fields: [
-        "diseaseFromSourceId"
-      ],
-      score-expr: """
-      element_at(
-        map(
-          'Assessed', 1.0,
-          'Not yet assessed', 0.5
-        ),
-        confidence
-      )
-      """
-    },
-    {
        id: "cancer_genome_interpreter"
        unique-fields: [
          "biomarkerName",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -849,22 +849,6 @@ evidences {
       """
     },
     {
-      id: "orphanet"
-      datatype-id: "genetic_association"
-      unique-fields: [
-        "diseaseFromSourceId"
-      ],
-      score-expr: """
-      element_at(
-        map(
-          'Assessed', 1.0,
-          'Not yet assessed', 0.5
-        ),
-        confidence
-      )
-      """
-    },
-    {
       id: "cancer_genome_interpreter"
       unique-fields: [
         "biomarkerName",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -863,6 +863,17 @@ evidences {
         confidence
       )
       """
+    },
+    {
+      id: "cancer_genome_interpreter"
+      unique-fields: [
+        "biomarkerName",
+        "confidence",
+        "diseaseFromSource",
+        "drugFromSource",
+        "drugResponse"
+      ],
+      score-expr: "1.0"
     }
   ]
 }
@@ -923,6 +934,7 @@ associations {
     {id: "progeny", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "slapenrich", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "sysbio", weight: 0.5, data-type = "affected_pathway", propagate = true},
+    {id: "cancer_genome_interpreter", weight: 0.5, data-type = "affected_pathway", propagate = true},
   ]
 }
 


### PR DESCRIPTION
Cancer biomarkers were previously part of the target annotation.

It is now forming part of the evidence data sources with the name `cancer_genome_interpreter`.
- The new data source has been added to the main config file
- The new data source has been added to the 21.09 config version
- `orphanet`'s config was duplicated in both config files. I've kept the more cramped one. 