### PR TITLE
1739 add evidence schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ The `options` field configures how Spark will read the input files. Both Json an
 configurable options, details of which can be
 found [in the documentation](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html)
 
+#### Schema
+
+You can optionally provide a schema for input files, for example:
+
+```hocon
+inputs {
+  raw-evidences {
+    format = "json"
+    path = ${common.input}"/evidence-files//*"
+    schema = """
+            `datasourceId` STRING,`targetId` STRING,`alleleOrigins` ARRAY<STRING>, ...
+             """
+  }
+}
+```
+
+If you want to extract the schema from an existing dataframe, follow the following steps:
+
+```scala
+val df: DataFrame = ???
+val schema: String = df.schema.toDDL
+println(schema)
+```
+
 #### Configuring Spark
 
 If you want to use a local installation of Spark customise the `application.conf` with the following spark-uri field and

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -485,9 +485,6 @@ known-drugs {
 }
 
 evidences {
-  schema = """
- `datasourceId` STRING,`targetId` STRING,`alleleOrigins` ARRAY<STRING>,`allelicRequirements` ARRAY<STRING>,`biologicalModelAllelicComposition` STRING,`biologicalModelGeneticBackground` STRING,`biologicalModelId` STRING,`biosamplesFromSource` ARRAY<STRING>,`clinicalPhase` BIGINT,`clinicalSignificances` ARRAY<STRING>,`clinicalStatus` STRING,`cohortDescription` STRING,`cohortId` STRING,`cohortPhenotypes` ARRAY<STRING>,`cohortShortName` STRING,`confidence` STRING,`contrast` STRING,`datatypeId` STRING,`diseaseCellLines` ARRAY<STRING>,`diseaseFromSource` STRING,`diseaseFromSourceId` STRING,`diseaseFromSourceMappedId` STRING,`diseaseModelAssociatedHumanPhenotypes` ARRAY<STRUCT<`id`: STRING, `label`: STRING>>,`diseaseModelAssociatedModelPhenotypes` ARRAY<STRUCT<`id`: STRING, `label`: STRING>>,`drugId` STRING,`literature` ARRAY<STRING>,`log2FoldChangePercentileRank` BIGINT,`log2FoldChangeValue` DOUBLE,`mutatedSamples` ARRAY<STRUCT<`functionalConsequenceId`: STRING, `numberMutatedSamples`: BIGINT, `numberSamplesTested`: BIGINT, `numberSamplesWithMutationType`: BIGINT>>,`oddsRatio` DOUBLE,`pathways` ARRAY<STRUCT<`id`: STRING, `name`: STRING>>,`reactionId` STRING,`reactionName` STRING,`resourceScore` DOUBLE,`significantDriverMethods` ARRAY<STRING>,`studyCases` BIGINT,`studyId` STRING,`studyOverview` STRING,`studyStartDate` STRING,`studyStopReason` STRING,`targetFromSource` STRING,`targetFromSourceId` STRING,`targetInModel` STRING,`targetInModelId` STRING,`targetModulation` STRING,`urls` ARRAY<STRUCT<`niceName`: STRING, `url`: STRING>>,`variantAminoacidDescriptions` ARRAY<STRING>,`variantFunctionalConsequenceId` STRING,`variantId` STRING,`variantRsId` STRING,`diseaseId` STRING,`id` STRING,`score` DOUBLE
-  """
   outputs {
     succeeded {
       format = ${common.output-format}
@@ -505,7 +502,6 @@ evidences {
     raw-evidences {
       format = "json"
       path = ${common.input}"/evidence-files//*"
-      schema = ${evidences.schema}
     }
     diseases {
       format = ${common.output-format}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -68,55 +68,55 @@ reactome {
 }
 
 expression {
-    rna {
-      format = "csv"
-      path = ${common.input}"/annotation-files/hpa/baseline_expression_counts-2020-05-07.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "true"}
-        {k: "inferSchema", v: "true"}
-      ]
-    }
-    binned {
-      format = "csv"
-      path = ${common.input}"/annotation-files/hpa/baseline_expression_binned-2020-05-07.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "true"}
-        {k: "inferSchema", v: "true"}
-      ]
-    }
-    zscore {
-      format = "csv"
-      path = ${common.input}"/annotation-files/hpa/baseline_expression_zscore_binned-2020-05-07.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "true"}
-        {k: "inferSchema", v: "true"}
-      ]
-    }
-    exprhierarchy {
-      format = "csv"
-      path = ${common.input}"/annotation-files/hpa/expression_hierarchy_curation-2021-08-09.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "false"}
-        {k: "inferSchema", v: "true"}
-      ]
-    }
-    efomap {
-      format = "json"
-      path = ${common.input}"/annotation-files/hpa/map_with_efos-2021-08-09.json"
-    }
-    tissues {
-      format = "csv"
-      path = ${common.input}"/annotation-files/hpa/normal_tissue-2021-08-09.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "true"}
-        {k: "inferSchema", v: "true"}
-      ]
-    }
+  rna {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_counts-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  binned {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_binned-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  zscore {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/baseline_expression_zscore_binned-2020-05-07.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  exprhierarchy {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/expression_hierarchy_curation-2021-08-09.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "false"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  efomap {
+    format = "json"
+    path = ${common.input}"/annotation-files/hpa/map_with_efos-2021-08-09.json"
+  }
+  tissues {
+    format = "csv"
+    path = ${common.input}"/annotation-files/hpa/normal_tissue-2021-08-09.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
   output = {
     format = ${common.output-format}
     path = ${common.output}"/baselineExpression"
@@ -188,7 +188,7 @@ target {
     chembl = ${drug.chembl-target}
     chemical-probes = {
       format = "json"
-      path =  ${common.input}"/target-inputs/chemicalprobes-2021-08-18.json"
+      path = ${common.input}"/target-inputs/chemicalprobes-2021-08-18.json"
     }
     ensembl {
       format = "json"
@@ -485,6 +485,9 @@ known-drugs {
 }
 
 evidences {
+  schema = """
+ `datasourceId` STRING,`targetId` STRING,`alleleOrigins` ARRAY<STRING>,`allelicRequirements` ARRAY<STRING>,`biologicalModelAllelicComposition` STRING,`biologicalModelGeneticBackground` STRING,`biologicalModelId` STRING,`biosamplesFromSource` ARRAY<STRING>,`clinicalPhase` BIGINT,`clinicalSignificances` ARRAY<STRING>,`clinicalStatus` STRING,`cohortDescription` STRING,`cohortId` STRING,`cohortPhenotypes` ARRAY<STRING>,`cohortShortName` STRING,`confidence` STRING,`contrast` STRING,`datatypeId` STRING,`diseaseCellLines` ARRAY<STRING>,`diseaseFromSource` STRING,`diseaseFromSourceId` STRING,`diseaseFromSourceMappedId` STRING,`diseaseModelAssociatedHumanPhenotypes` ARRAY<STRUCT<`id`: STRING, `label`: STRING>>,`diseaseModelAssociatedModelPhenotypes` ARRAY<STRUCT<`id`: STRING, `label`: STRING>>,`drugId` STRING,`literature` ARRAY<STRING>,`log2FoldChangePercentileRank` BIGINT,`log2FoldChangeValue` DOUBLE,`mutatedSamples` ARRAY<STRUCT<`functionalConsequenceId`: STRING, `numberMutatedSamples`: BIGINT, `numberSamplesTested`: BIGINT, `numberSamplesWithMutationType`: BIGINT>>,`oddsRatio` DOUBLE,`pathways` ARRAY<STRUCT<`id`: STRING, `name`: STRING>>,`reactionId` STRING,`reactionName` STRING,`resourceScore` DOUBLE,`significantDriverMethods` ARRAY<STRING>,`studyCases` BIGINT,`studyId` STRING,`studyOverview` STRING,`studyStartDate` STRING,`studyStopReason` STRING,`targetFromSource` STRING,`targetFromSourceId` STRING,`targetInModel` STRING,`targetInModelId` STRING,`targetModulation` STRING,`urls` ARRAY<STRUCT<`niceName`: STRING, `url`: STRING>>,`variantAminoacidDescriptions` ARRAY<STRING>,`variantFunctionalConsequenceId` STRING,`variantId` STRING,`variantRsId` STRING,`diseaseId` STRING,`id` STRING,`score` DOUBLE
+  """
   outputs {
     succeeded {
       format = ${common.output-format}
@@ -502,6 +505,7 @@ evidences {
     raw-evidences {
       format = "json"
       path = ${common.input}"/evidence-files//*"
+      schema = ${evidences.schema}
     }
     diseases {
       format = ${common.output-format}
@@ -976,63 +980,63 @@ search {
 // OpenFDA FAERS Configuration
 
 openfda {
-    // NOTE - Each step seems to have a commong baseline path that should be refactored
-    step-root-input-path = ${common.input}"/fda"
-    step-root-output-path = ${common.output}"/fda"
-    // Source data
-    chembl-drugs {
-        format = ${common.output-format}
-        path = ${drug.outputs.drug.path}
+  // NOTE - Each step seems to have a commong baseline path that should be refactored
+  step-root-input-path = ${common.input}"/fda"
+  step-root-output-path = ${common.output}"/fda"
+  // Source data
+  chembl-drugs {
+    format = ${common.output-format}
+    path = ${drug.outputs.drug.path}
+  }
+  fda-data {
+    format = "json"
+    path = ${openfda.step-root-input-path}"/*.jsonl"
+  }
+  blacklisted-events {
+    format = "csv"
+    path = ${openfda.step-root-input-path}"/blacklisted_events.txt"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "ignoreLeadingWhiteSpace", v: "true"},
+      {k: "ignoreTrailingWhiteSpace", v: "true"}
+    ]
+  }
+  meddra {
+    meddra-preferred-terms {
+      format = "csv"
+      // Change this to whatever location the data is sitting on
+      path = ${openfda.step-root-input-path}"/meddra/MedAscii/pt.asc"
     }
-    fda-data {
-        format = "json"
-        path = ${openfda.step-root-input-path}"/*.jsonl"
+    meddra-low-level-terms {
+      format = "csv"
+      // Change this to whatever location the data is sitting on
+      path = ${openfda.step-root-input-path}"/meddra/MedAscii/llt.asc"
     }
-    blacklisted-events {
-        format = "csv"
-        path = ${openfda.step-root-input-path}"/blacklisted_events.txt"
-        options = [
-            {k: "sep", v: "\\t"},
-            {k: "ignoreLeadingWhiteSpace", v: "true"},
-            {k: "ignoreTrailingWhiteSpace", v: "true"}
-        ]
+  }
+  meddra-preferred-terms-cols = ["pt_code", "pt_name"]
+  meddra-low-level-terms-cols = ["llt_code", "llt_name"]
+  montecarlo {
+    permutations: 100
+    percentile: 0.95
+  }
+  sampling {
+    size = 0.1
+    enabled = false
+  }
+  outputs = {
+    fda-unfiltered {
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/unfiltered"
     }
-    meddra {
-        meddra-preferred-terms {
-            format = "csv"
-            // Change this to whatever location the data is sitting on
-            path = ${openfda.step-root-input-path}"/meddra/MedAscii/pt.asc"
-        }
-        meddra-low-level-terms {
-            format = "csv"
-            // Change this to whatever location the data is sitting on
-            path = ${openfda.step-root-input-path}"/meddra/MedAscii/llt.asc"
-        }
-    }
-    meddra-preferred-terms-cols = ["pt_code", "pt_name"]
-    meddra-low-level-terms-cols = ["llt_code", "llt_name"]
-    montecarlo {
-        permutations: 100
-        percentile: 0.95
+    fda-results {
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/results"
     }
     sampling {
-        size = 0.1
-        enabled = false
+      format = ${common.output-format}
+      path = ${openfda.step-root-output-path}"/sample"
     }
-    outputs = {
-        fda-unfiltered {
-            format = ${common.output-format}
-            path = ${openfda.step-root-output-path}"/unfiltered"
-        }
-        fda-results {
-            format = ${common.output-format}
-            path = ${openfda.step-root-output-path}"/results"
-        }
-        sampling {
-            format = ${common.output-format}
-            path = ${openfda.step-root-output-path}"/sample"
-        }
-    }
+  }
 
 }
 
@@ -1042,7 +1046,7 @@ ebisearch {
     format = ${common.output-format}
     path = ${common.output}"/targets"
   }
- evidence-etl {
+  evidence-etl {
     format = ${common.output-format}
     path = ${evidences.outputs.succeeded.path}"/sourceId=ot_genetics_portal/"
   }
@@ -1063,13 +1067,13 @@ ebisearch {
 otarproject {
   disease-etl = ${disease.outputs.diseases}
   otar {
-      format = "csv"
-      path = ${common.input}"/annotation-files/otar/otar_projects.tsv"
-      options = [
-        {k: "sep", v: "\\t"},
-        {k: "header", v: "true"}
-        {k: "inferSchema", v: "true"}
-      ]
+    format = "csv"
+    path = ${common.input}"/annotation-files/otar/otar_projects.tsv"
+    options = [
+      {k: "sep", v: "\\t"},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
   }
   output = {
     format = ${common.output-format}

--- a/src/main/scala/io/opentargets/etl/backend/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Evidence.scala
@@ -229,12 +229,21 @@ object Evidence extends LazyLogging {
 
     logger.info("validate each evidence generating a hash to check for duplicates")
     val config = context.configuration.evidences
-
+    val allRequiredColumns: Set[String] = config.dataSources
+      .flatMap(_.uniqueFields)
+      .toSet ++ config.uniqueFields.toSet
+    val missingColumns = allRequiredColumns diff df.columns.toSet
+    logger.warn(s"Missing columns in evidence $missingColumns. Creating synthetic columns.")
+    val validatedDF =
+      if (missingColumns.nonEmpty)
+        missingColumns.foldLeft(df)((acc, missingColumn) => acc.withColumn(missingColumn, lit("")))
+      else df
     val commonReqFields = config.uniqueFields.toSet
-    val dts = config.dataSources.map { dt =>
-      (col("sourceId") === dt.id) -> (commonReqFields ++ dt.uniqueFields.toSet).toList.sorted
-        .map(x => when(expr(x).isNotNull, expr(x).cast(StringType)).otherwise(""))
-    }
+    val dts: List[(Column, List[Column])] = config.dataSources.map(
+      dt =>
+        (col("sourceId") === dt.id) ->
+          (commonReqFields ++ dt.uniqueFields.toSet).toList.sorted
+            .map(x => when(expr(x).isNotNull, expr(x).cast(StringType)).otherwise("")))
 
     val defaultDts = commonReqFields.toList.sorted.map { x =>
       when(col(x).isNotNull, col(x).cast(StringType)).otherwise("")
@@ -246,7 +255,7 @@ object Evidence extends LazyLogging {
       }
       .otherwise(sha1(concat(defaultDts: _*)))
 
-    df.withColumn(columnName, hashes)
+    validatedDF.withColumn(columnName, hashes)
   }
 
   def score(df: DataFrame, columnName: String)(implicit context: ETLSessionContext): DataFrame = {

--- a/src/main/scala/io/opentargets/etl/backend/spark/IoHelpers.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/IoHelpers.scala
@@ -5,7 +5,8 @@ import io.opentargets.etl.backend.Configuration.OTConfig
 import io.opentargets.etl.backend.ETLSessionContext
 import monocle.macros.syntax.lens.toGenApplyLensOps
 import org.apache.spark.sql.functions.current_timestamp
-import org.apache.spark.sql.{DataFrame, DataFrameWriter, Row, SparkSession}
+import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.{DataFrame, DataFrameReader, DataFrameWriter, Row, SparkSession}
 
 import scala.util.Random
 
@@ -22,12 +23,14 @@ case class IOResource(data: DataFrame, configuration: IOResourceConfig)
   * @param path        to resource
   * @param options     configuration options
   * @param partitionBy partition results by
+  * @param schema      in json format to specify dataframe format.
   */
 case class IOResourceConfig(
     format: String,
     path: String,
     options: Option[Seq[IOResourceConfigOption]] = None,
-    partitionBy: Option[Seq[String]] = None
+    partitionBy: Option[Seq[String]] = None,
+    schema: Option[String] = None
 )
 
 case class Metadata(id: String,
@@ -75,13 +78,17 @@ object IoHelpers extends LazyLogging {
   def loadFileToDF(pathInfo: IOResourceConfig)(implicit session: SparkSession): DataFrame = {
     logger.info(s"load dataset ${pathInfo.path} with ${pathInfo.toString}")
 
-    pathInfo.options
+    val dfrWithOption: DataFrameReader = pathInfo.options
       .foldLeft(session.read.format(pathInfo.format)) {
         case ops =>
           val options = ops._2.map(c => c.k -> c.v).toMap
           ops._1.options(options)
       }
-      .load(pathInfo.path)
+
+    pathInfo.schema match {
+      case Some(value) => dfrWithOption.schema(value).load(pathInfo.path)
+      case None        => dfrWithOption.load(pathInfo.path)
+    }
   }
 
   /**


### PR DESCRIPTION
Resolves opentargets/platform#1739

I've built in the functionality where we can use a specific schema on input files. This mechanism didn't solve the problem we were having though of the step failing when there were missing inputs. Not all of the `datasources.unique-fields` in the `reference.conf` file are actually included in the output file (eg. `statisticalTestTail`) so missing input files can still cause the step to fail. 

I've addressed this by checking which of the unique fields in missing and creating those 'fake' columns. 