### PR TITLE
1745 safety data bugs

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -324,12 +324,12 @@ target {
       ]
     }
     safety-adverse-event {
-      format = "parquet"
-      path = ${common.input}"/target-inputs/safety/ae_safety/*.parquet"
+      format = "json"
+      path = ${common.input}"/target-inputs/safety/ae.json"
     }
     safety-safety-risk {
-      format = "parquet"
-      path = ${common.input}"/target-inputs/safety/sr_safety/*.parquet"
+      format = "json"
+      path = ${common.input}"/target-inputs/safety/sr.json"
     }
     tep {
       format = "json"

--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -110,7 +110,12 @@ object Safety extends LazyLogging {
         lit(null) as "cellId"
       ) as "biosample",
       col("ref") as "datasource",
-      col("pmid") as "literature"
+      col("pmid") as "literature",
+      struct(
+        lit(null) as "name",
+        col("liability") as "description",
+        lit(null) as "type"
+      ) as "study"
     )
   }
 

--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -102,6 +102,10 @@ object Safety extends LazyLogging {
     logger.debug("Transforming target safety safety risk data.")
     df.select(
       col("ensemblId") as "id",
+      when(col("ref").contains("Force"), "heart disease")
+        .when(col("ref").contains("Lamore"), "cardiac arrhythmia") as "event",
+      when(col("ref").contains("Force"), "EFO_0003777")
+        .when(col("ref").contains("Lamore"), "EFO_0004269") as "eventId",
       struct(
         col("biologicalSystem") as "tissueLabel",
         col("uberonId") as "tissueId",

--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -100,27 +100,28 @@ object Safety extends LazyLogging {
 
   private def transformTargetSafety(df: DataFrame): DataFrame = {
     logger.debug("Transforming target safety safety risk data.")
-    df.select(
-      col("ensemblId") as "id",
-      when(col("ref").contains("Force"), "heart disease")
-        .when(col("ref").contains("Lamore"), "cardiac arrhythmia") as "event",
-      when(col("ref").contains("Force"), "EFO_0003777")
-        .when(col("ref").contains("Lamore"), "EFO_0004269") as "eventId",
-      struct(
-        col("biologicalSystem") as "tissueLabel",
-        col("uberonId") as "tissueId",
-        lit(null) as "cellLabel",
-        lit(null) as "cellFormat",
-        lit(null) as "cellId"
-      ) as "biosample",
-      col("ref") as "datasource",
-      col("pmid") as "literature",
-      struct(
-        lit(null) as "name",
-        col("liability") as "description",
-        lit(null) as "type"
-      ) as "study"
-    )
+    df.filter(col("ref") =!= "HeCaToS")
+      .select(
+        col("ensemblId") as "id",
+        when(col("ref").contains("Force"), "heart disease")
+          .when(col("ref").contains("Lamore"), "cardiac arrhythmia") as "event",
+        when(col("ref").contains("Force"), "EFO_0003777")
+          .when(col("ref").contains("Lamore"), "EFO_0004269") as "eventId",
+        struct(
+          col("biologicalSystem") as "tissueLabel",
+          col("uberonId") as "tissueId",
+          lit(null) as "cellLabel",
+          lit(null) as "cellFormat",
+          lit(null) as "cellId"
+        ) as "biosample",
+        col("ref") as "datasource",
+        col("pmid") as "literature",
+        struct(
+          lit(null) as "name",
+          col("liability") as "description",
+          lit(null) as "type"
+        ) as "study"
+      )
   }
 
   def transformToxCast(toxDF: DataFrame, geneIdLookup: DataFrame): DataFrame = {

--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -128,7 +128,7 @@ object Safety extends LazyLogging {
           lit("") as "cellId"
         ) as "biosample",
         trim(col("official_symbol")) as "official_symbol",
-        lit("Toxcast") as "datasource",
+        lit("ToxCast") as "datasource",
         struct(col("assay_component_endpoint_name") as "name",
                col("assay_component_desc") as "description",
                col("assay_format_type") as "type") as "study"


### PR DESCRIPTION
Resolves opentargets/platform#1745

- Updates `Toxcast` to `ToxCast`
- Adds custom events for references 'Force' and 'Lamore' (see commit message for more details)
- Adds description for 'Force', 'Lamore' and 'HeCaTos'
- Updates input files

@cmalangone I've added new input files to `open-targets-pre-data-releases/21.09.1/input/target-inputs/safety` and update `reference.conf`. These input files should never change between releases. 