### PR TITLE
fix issue with efo_code

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/Expression.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Expression.scala
@@ -186,7 +186,12 @@ object Expression extends LazyLogging {
       .drop("efo_code", "labelNew", "label", "name", "expressionId", "tissue_internal_id", "Tissue")
       .distinct
 
+    // Missing tissues.
+    val missingTissues = validTissues.filter(col("efoId").isNull).select("labelDef").distinct()
+    missingTissues.show(20)
+
     val protein = validTissues
+      .filter(col("efoId").isNotNull)
       .groupBy("Gene", "labelDef", "efoId", "anatomical_systems", "organs")
       .agg(
         max(col("ReliabilityMapDef")).as("reliability"),

--- a/src/main/scala/io/opentargets/etl/backend/Expression.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Expression.scala
@@ -186,9 +186,8 @@ object Expression extends LazyLogging {
       .drop("efo_code", "labelNew", "label", "name", "expressionId", "tissue_internal_id", "Tissue")
       .distinct
 
-    // Missing tissues.
-    val missingTissues = validTissues.filter(col("efoId").isNull).select("labelDef").distinct()
-    missingTissues.show(20)
+    // Missing tissues. Fixme.
+    // val missingTissues = validTissues.filter(col("efoId").isNull).select("labelDef").distinct()
 
     val protein = validTissues
       .filter(col("efoId").isNotNull)


### PR DESCRIPTION
The efo_code is a mandatory field in the GRAPHQL. 
Remove the expressions data without this info

https://app.zenhub.com/workspaces/open-targets-issue-tracker-58a421fd8c85e652659a1486/issues/opentargets/platform/1770