### PR TITLE
Update target safety to include general dosing effects.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Safety.scala
@@ -89,8 +89,7 @@ object Safety extends LazyLogging {
       .withColumn(
         "effects",
         struct(element_at(col("effects"), 1) as "direction",
-               when(element_at(col("effects"), 2) =!= "general", element_at(col("effects"), 2))
-                 .otherwise(null) as "dosing")
+               element_at(col("effects"), 2) as "dosing")
       )
 
     val effectsDF = aeDF


### PR DESCRIPTION
Update ETL to include target safety 'dosing' when the value is 'general'. We had previously filtered these out. 

Resolves opentargets/platform#1774