### PR TITLE
Remove unwanted columns on Target object.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/GeneWithLocation.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/GeneWithLocation.scala
@@ -42,6 +42,6 @@ object GeneWithLocation extends LazyLogging {
         "locations",
         safeArrayUnion(col("HPA_main"), col("HPA_additional"), col("HPA_extracellular_location")))
 
-    hpaDf.select(col("id"), col("locations")).as[GeneWithLocation]
+    hpaDf.as[GeneWithLocation].map(identity)
   }
 }

--- a/src/main/scala/io/opentargets/etl/backend/target/GeneWithLocation.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/GeneWithLocation.scala
@@ -42,6 +42,6 @@ object GeneWithLocation extends LazyLogging {
         "locations",
         safeArrayUnion(col("HPA_main"), col("HPA_additional"), col("HPA_extracellular_location")))
 
-    hpaDf.as[GeneWithLocation]
+    hpaDf.select(col("id"), col("locations")).as[GeneWithLocation]
   }
 }


### PR DESCRIPTION
Columns `HPA_main`, `HPA_additional`, `HPA_extracellular_location` were
not being dropped. Somewhat surprising behaviour since I would have
thought that the cast to a DS removed unwanted columns.