### PR TITLE
Add target validation step to ETL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,15 +162,24 @@ relationships at a more granular level, where inputs and outputs are specificall
 
 ## Step notes
 
+### Target Validation
+
+Inputs can be provided here where the only logic is to match an ENSG ID against an input column. Any input rows which
+can't be matched to a target in the platform will be discarded.
+
+Using mouse phenotypes as an example: we match on the column specified in the configuration `targetFromSourceId`. Any
+entry which cannot be matched to an ID in the platform's target dataset will be discarded.
+
 ### Drug
 
-The primary input source of the Drug dataset is ChEMBL. ChEMBL contains almost 2 million molecules, most which are are 
-not 'drugs'. We define a drug to be any molecule that meets one or more of the following criteria: 
- - There is at least 1 known indication;
- - There is at least 1 known mechanism of action; or
- - The ChEMBL ID can be mapped to a DrugBank ID.  
- 
-To run the `Drug` step use the example command under `Create a fat JAR` with `drug` as the step name. 
+The primary input source of the Drug dataset is ChEMBL. ChEMBL contains almost 2 million molecules, most which are are
+not 'drugs'. We define a drug to be any molecule that meets one or more of the following criteria:
+
+- There is at least 1 known indication;
+- There is at least 1 known mechanism of action; or
+- The ChEMBL ID can be mapped to a DrugBank ID.
+
+To run the `Drug` step use the example command under `Create a fat JAR` with `drug` as the step name.
 
 ### Baseline Expression
 The primary input sources of the baseline expression dataset are 

--- a/documentation/etl_current.puml
+++ b/documentation/etl_current.puml
@@ -17,6 +17,7 @@ artifact expression <<noDependency>>
 artifact go <<noDependency>>
 artifact interactions <<dependencies>>
 artifact knownDrugs <<dependencies>>
+artifact targetValidation<<dependencies>>
 artifact reactome <<noDependency>>
 artifact search <<dependencies>>
 artifact target <<dependencies>>
@@ -49,5 +50,7 @@ drug --> search
 associations --> search
 
 target --> interactions
+
+target --> targetValidation
 
 @enduml

--- a/documentation/etl_current_full.puml
+++ b/documentation/etl_current_full.puml
@@ -20,6 +20,7 @@ artifact knownDrugs <<dependencies>>
 artifact reactome <<noDependency>>
 artifact search <<dependencies>>
 artifact target <<dependencies>>
+artifact targetValidation <<dependencies>>
 
 'inputs
 ' association
@@ -123,9 +124,18 @@ interface searchTargetOutput <<output>>
 interface searchDiseaseOutput <<output>>
 interface searchDrugOutput <<output>>
 
+  ' targetValidation
+ interface mousePhenotypes <<input>>
+ interface mousePhenotypesOutput <<output>>
+
 
 
 ' relations
+
+  ' targetValidation
+targetOutput --> targetValidation
+mousePhenotypes --> targetValidation
+targetValidation --> mousePhenotypesOutput
   ' assocations
 targetOutput --> associations
 diseaseOutput --> associations

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,6 +11,7 @@ spark-settings {
 }
 common {
   default-steps = [
+    "targetValidation"
     "reactome",
     "disease",
     "target",
@@ -181,7 +182,6 @@ interactions {
     }
   }
 }
-
 
 target {
   input {
@@ -369,6 +369,30 @@ target {
     "7227-fly",
     "6239-worm",
   ]
+}
+
+target-validation {
+  inputs = [
+    {
+      name = "mousePhenotypes"
+      id-column = "targetFromSourceId"
+      data = {
+        format = "json"
+        path = ${common.input}"/mousePhenotypes"
+      }
+    }
+  ]
+  target = ${target.outputs.target}
+  output {
+    succeeded {
+      format = ${common.output-format}
+      path = ${common.output}"/targetValidation"
+    }
+    failed {
+      format = ${common.output-format}
+      path = ${common.output}"/targetValidationFailed"
+    }
+  }
 }
 
 disease {

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -16,6 +16,9 @@ object ETL extends LazyLogging {
     step match {
       case "test" =>
         ETLPipeline
+      case "targetValidation" =>
+        logger.info("run step targetValidation")
+        TargetValidation()
       case "evidence" =>
         logger.info("run step evidence")
         Evidence()
@@ -79,8 +82,7 @@ object ETL extends LazyLogging {
           if (steps.isEmpty) otContext.configuration.common.defaultSteps
           else steps
 
-        val unknownSteps = etlSteps filterNot otContext.configuration.common.defaultSteps.contains
-        val knownSteps = etlSteps filter otContext.configuration.common.defaultSteps.contains
+        val (knownSteps, unknownSteps) = etlSteps partition otContext.configuration.common.defaultSteps.contains
 
         logger.info(s"valid steps to execute: $knownSteps")
         if (unknownSteps.nonEmpty) logger.warn(s"invalid steps to skip: $unknownSteps")

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -32,14 +32,14 @@ object Configuration extends LazyLogging {
                                    diseases: IOResourceConfig,
                                    targets: IOResourceConfig)
 
-  case class EvidenceOutputsSection(succeeded: IOResourceConfig, failed: IOResourceConfig)
+  case class SucceedFailedOutputs(succeeded: IOResourceConfig, failed: IOResourceConfig)
 
   case class EvidencesSection(inputs: EvidenceInputsSection,
                               uniqueFields: List[String],
                               scoreExpr: String,
                               datatypeId: String,
                               dataSources: List[EvidenceEntry],
-                              outputs: EvidenceOutputsSection)
+                              outputs: SucceedFailedOutputs)
 
   case class AssociationInputsSection(evidences: IOResourceConfig, diseases: IOResourceConfig)
 
@@ -144,12 +144,11 @@ object Configuration extends LazyLogging {
 
   case class GeneOntologySection(goInput: IOResourceConfig, output: IOResourceConfig)
 
-  case class MousePhenotypes(mpClasses: IOResourceConfig,
-                             mpReports: IOResourceConfig,
-                             mpOrthology: IOResourceConfig,
-                             mpCategories: IOResourceConfig,
-                             target: IOResourceConfig,
-                             output: IOResourceConfig)
+  case class TargetValidationInput(name: String, idColumn: String, data: IOResourceConfig)
+
+  case class TargetValidation(inputs: Seq[TargetValidationInput],
+                              target: IOResourceConfig,
+                              output: SucceedFailedOutputs)
 
   case class SearchInputsSection(evidences: IOResourceConfig,
                                  diseases: IOResourceConfig,
@@ -270,6 +269,7 @@ object Configuration extends LazyLogging {
       search: SearchSection,
       aotf: AOTFSection,
       target: Target,
+      targetValidation: TargetValidation,
       expression: ExpressionSection,
       openfda: OpenfdaSection,
       ebisearch: EBISearchSection,

--- a/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
+++ b/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
@@ -51,10 +51,9 @@ object TargetValidation extends Serializable with LazyLogging {
     */
   def validate(df: DataFrame, idColumn: String)(
       implicit targetDf: DataFrame): (DataFrame, DataFrame) = {
-    val tid = Random.alphanumeric.take(6).mkString
-    val t = targetDf.select(col("id") as tid)
+
     val cleanedDf = df
-      .join(t, t(tid) === df(idColumn), "left_semi")
+      .join(targetDf, targetDf("id") === df(idColumn), "left_semi")
 
     val missing = df.join(cleanedDf.select(idColumn), Seq(idColumn), "left_anti")
 

--- a/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
+++ b/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
@@ -31,8 +31,8 @@ object TargetValidation extends Serializable with LazyLogging {
             s"${it.name}-failed" -> IOResource(
               missing_targets_df,
               context.configuration.targetValidation.output.failed
-                .copy(
-                  path = s"${context.configuration.targetValidation.output.failed.path}/${it.name}")
+                .copy(path =
+                  s"${context.configuration.targetValidation.output.failed.path}/${it.name}Failed")
             )
           )
         }
@@ -54,8 +54,7 @@ object TargetValidation extends Serializable with LazyLogging {
     val tid = Random.alphanumeric.take(6).mkString
     val t = targetDf.select(col("id") as tid)
     val cleanedDf = df
-      .join(t, t(tid) === df(idColumn))
-      .drop(tid)
+      .join(t, t(tid) === df(idColumn), "left_semi")
 
     val missing = df.join(cleanedDf.select(idColumn), Seq(idColumn), "left_anti")
 

--- a/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
+++ b/src/main/scala/io/opentargets/etl/backend/TargetValidation.scala
@@ -1,0 +1,64 @@
+package io.opentargets.etl.backend
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.spark.{IOResource, IoHelpers}
+import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.functions.col
+
+import scala.util.Random
+
+object TargetValidation extends Serializable with LazyLogging {
+
+  def apply()(implicit context: ETLSessionContext): IOResources = {
+    implicit val ss: SparkSession = context.sparkSession
+
+    implicit val target_df: DataFrame =
+      IoHelpers.loadFileToDF(context.configuration.targetValidation.target)
+    val rs: Seq[(String, IOResource)] = {
+      for (it <- context.configuration.targetValidation.inputs)
+        yield {
+          logger.info(s"Target Validation -- checking ${it.name}")
+          val df = IoHelpers.loadFileToDF(it.data)
+          val (valid_targets_df, missing_targets_df) = validate(df, it.idColumn)
+          Seq(
+            s"${it.name}-succeeded" -> IOResource(
+              valid_targets_df,
+              context.configuration.targetValidation.output.succeeded
+                .copy(path =
+                  s"${context.configuration.targetValidation.output.succeeded.path}/${it.name}")
+            ),
+            s"${it.name}-failed" -> IOResource(
+              missing_targets_df,
+              context.configuration.targetValidation.output.failed
+                .copy(
+                  path = s"${context.configuration.targetValidation.output.failed.path}/${it.name}")
+            )
+          )
+        }
+    } flatten
+
+    IoHelpers.writeTo(rs.toMap)
+  }
+
+  /**
+    *
+    * @param df       to validate
+    * @param idColumn column which contains ENSG ids
+    * @param targetDf output of ETL target step
+    * @return tuple of dataframes: left side includes df with rows removed which did not correspond to a row in
+    *         {@code targetDf}. Right side are all the rows which were removed from @{code df}.
+    */
+  def validate(df: DataFrame, idColumn: String)(
+      implicit targetDf: DataFrame): (DataFrame, DataFrame) = {
+    val tid = Random.alphanumeric.take(6).mkString
+    val t = targetDf.select(col("id") as tid)
+    val cleanedDf = df
+      .join(t, t(tid) === df(idColumn))
+      .drop(tid)
+
+    val missing = df.join(cleanedDf.select(idColumn), Seq(idColumn), "left_anti")
+
+    (cleanedDf, missing)
+  }
+}

--- a/src/test/scala/io/opentargets/etl/backend/TargetValidationTest.scala
+++ b/src/test/scala/io/opentargets/etl/backend/TargetValidationTest.scala
@@ -1,0 +1,28 @@
+package io.opentargets.etl.backend
+
+import org.apache.spark.sql.DataFrame
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class TargetValidationTest extends EtlSparkUnitTest {
+
+  "Validate" should "partition a dataframe based on whether an ENSG ID can be found in the target dataset" in {
+    import sparkSession.implicits._
+    // given
+    implicit val targetDF: DataFrame = 1 to 10 by 2 map { i =>
+      (s"ENSG$i", i)
+    } toDF ("id", "row")
+    val filterColumn = "fid"
+    val dfToFilter = 1 to 10 map { i =>
+      (s"ENSG$i", i)
+    } toDF (filterColumn, "data")
+
+    // when
+    val results = TargetValidation.validate(dfToFilter, filterColumn)
+
+    /*
+     then the dataframes should be the same size since we have 10 unique targets and 5 unique other results, so 5 results
+     should be validated, and 5 results are listed as missing.
+     */
+    results._1.count() should equal(results._2.count)
+  }
+}


### PR DESCRIPTION
Target validation step is used for cases when we only want to check that
all the rows in a dataset are also present in the target dataset. In
this way we ensure that ETL outputs link up nicely and we don't have
polluted datasets.

Resolves opentargets/platform#1798