### PR TITLE
Update targetValidation configuration.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -390,7 +390,7 @@ target-validation {
     }
     failed {
       format = ${common.output-format}
-      path = ${common.output}"/targetValidationFailed"
+      path = ${common.output}"/targetValidationUnmatched"
     }
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,10 +11,10 @@ spark-settings {
 }
 common {
   default-steps = [
-    "targetValidation"
     "reactome",
     "disease",
     "target",
+    "targetValidation"
     "expression",
     "otar",
     "evidence",
@@ -386,7 +386,7 @@ target-validation {
   output {
     succeeded {
       format = ${common.output-format}
-      path = ${common.output}"/targetValidation"
+      path = ${common.output}
     }
     failed {
       format = ${common.output-format}


### PR DESCRIPTION
- Move targetValidation step to after 'target' in default steps. Since
'targetValidation' has a dependency on target, it needs to come after it
 in default steps.
- Flatten targetValidation output. Using mouse phenotypes as an example,
 the output now looks like:
 ```
 output |
        | metadata
        | -- mousePhenotypes
        | -- mousePhenotypesFailed
        | mousePhenotypes
        | targetValidationFailed
        | -- mousePhenotypes
```