### PR TITLE
Adding configuration for the encore evidence set

### DIFF
--- a/configuration/2021/21_09.conf
+++ b/configuration/2021/21_09.conf
@@ -524,6 +524,17 @@ evidences {
       score-expr: "element_at(map(0, 0.09, 1, 0.1, 2, 0.2, 3, 0.7, 4, 1.0), clinicalPhase)"
     },
     {
+      id: "encore",
+      datatype-id: "ot_partner",
+      unique-fields: [
+        "targetFromSourceId",
+        "interactingTargetFromSourceId",
+        "diseaseFromSourceMappedId"
+        "cellType"
+      ],
+      score-expr: "pvalue_linear_score(geneticInteractionPValue, 1.0, 0.01, 0.0, 1.0)"
+    },
+    {
       id: "europepmc",
       unique-fields: [
         "literature"

--- a/configuration/2021/21_09.conf
+++ b/configuration/2021/21_09.conf
@@ -529,7 +529,7 @@ evidences {
       unique-fields: [
         "targetFromSourceId",
         "interactingTargetFromSourceId",
-        "diseaseFromSourceMappedId"
+        "diseaseFromSourceMappedId",
         "cellType"
       ],
       score-expr: "pvalue_linear_score(geneticInteractionPValue, 1.0, 0.01, 0.0, 1.0)"


### PR DESCRIPTION
Modification contains:
* new field for evidence data-sources with id = encore
* defined list of unique association fields.
* score expression describing how the p-value needs to be processed