### PR TITLE
Update drug mechanisms of action ID mapping.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
@@ -111,7 +111,7 @@ object MechanismOfAction extends LazyLogging {
     val genes = gene.select(geneCols: _*)
 
     targetDf
-      .join(genes, Seq("uniprot_id"), "left_outer")
+      .join(genes, targetDf("uniprot_id") === genes("uniprot_id") || targetDf("uniprot_id") === genes("geneId"), "left_outer")
       .groupBy("target_chembl_id", "targetName", "targetType")
       .agg(array_distinct(collect_list("geneId")).as("targets"))
   }


### PR DESCRIPTION
Oligonucleotides like NUSINERSEN or GOLODIRSEN target human
mRNAs instead of human proteins. To capture these we need to
map MOA against both protein and gene IDs.

Resolves opentargets/platform#1787