### PR TITLE
Update Uniprot CommentIdentifiers for non-standard location.

### DIFF
--- a/src/main/scala/io/opentargets/etl/preprocess/uniprot/CommentIdentifiers.scala
+++ b/src/main/scala/io/opentargets/etl/preprocess/uniprot/CommentIdentifiers.scala
@@ -65,13 +65,20 @@ trait CommentIdentifiers {
   }
 
   private def parseLocations(location: String): Seq[String] = {
+    val isoformR = """\[Isoform [A-Z](\.)[0-9]\]:.+""" r
     val noNotes = location
       .split("Note=")
 
     val a: Array[String] = noNotes.headOption
       .map(opt => {
-        opt
+        val cleanedOfReferences = opt
           .replaceAll("\\{.+?\\}", "")
+        // handle case where Uniprot record isn't standard, having form [Isoform A.1]:...
+        val isoformStandardised: String = cleanedOfReferences match {
+          case isoformR(_*) => cleanedOfReferences.replaceFirst("\\.", "-")
+          case _            => cleanedOfReferences
+        }
+        isoformStandardised
           .split("\\.")
           .map(_.trim)
           .filter(!_.startsWith("Note="))

--- a/src/test/scala/io/opentargets/etl/preprocess/UniprotConverterTest.scala
+++ b/src/test/scala/io/opentargets/etl/preprocess/UniprotConverterTest.scala
@@ -109,6 +109,8 @@ class UniprotConverterTest
       "{ECO:0000269|PubMed:11148210, ECO:0000269|PubMed:11341771}",
       "-!- SUBCELLULAR LOCATION: Cell projection, cilium, photoreceptor outer",
       "segment {ECO:0000269|PubMed:27613864}. Membrane",
+      "-!- SUBCELLULAR LOCATION: [Isoform A.1]: Cell membrane; Single-pass type I membrane protein.",
+      "-!- SUBCELLULAR LOCATION: [Isoform A.2]: Cell membrane; Single-pass type I",
       "{ECO:0000269|PubMed:27613864}; Lipid-anchor",
       "{ECO:0000269|PubMed:27613864}; Cytoplasmic side",
       "{ECO:0000250|UniProtKB:Q00LT2}. Endoplasmic reticulum",
@@ -122,7 +124,7 @@ class UniprotConverterTest
     // when
     val results = updateComments(commentsRaw.toIterator)
     // then
-    results.locations should have size 6
+    results.locations should have size 8
     results.functions should have size 1
   }
 


### PR DESCRIPTION
There is a single entry in the Uniprot data which has a non-standard
location form. Because we were splitting on the period character we were
 breaking this incorrectly resulting in multiple false entries.

Resolves opentargets/platform#1842