### PR TITLE
Fix evidence exclusion mechanism

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -562,7 +562,7 @@ evidences {
 
   score-expr = "resourceScore"
   datatype-id = "other"
-  data-sources-exclude = ["ot_crisp", "encore"]
+  data-sources-exclude = []
   data-sources = [
     {
       id: "chembl",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -562,7 +562,7 @@ evidences {
 
   score-expr = "resourceScore"
   datatype-id = "other"
-  data-sources-exclude = []
+  data-sources-exclude = ["ot_crisp", "encore"]
   data-sources = [
     {
       id: "chembl",

--- a/src/main/scala/io/opentargets/etl/backend/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Evidence.scala
@@ -230,12 +230,10 @@ object Evidence extends LazyLogging {
     val config = context.configuration.evidences
 
     logger.info("Validate each evidence: generating a hash to check for duplicates")
-    logger.info(s"Excluding datasources: ${config.dataSourcesExclude.mkString("", ",", "")}")
 
     val commonReqFields = config.uniqueFields.toSet
 
     val dataTypes: List[(Column, List[Column])] = config.dataSources
-      .withFilter(ds => !config.dataSourcesExclude.contains(ds.id))
       .map(
         dataType =>
           (col("sourceId") === dataType.id) ->


### PR DESCRIPTION
**Only @cmalangone to merge!!**

This was implemented as part of opentargets/platform#1739 but didn't
work in some cases because the `score` method on Associations pulled the
 config from the implicit scope. The last fix only implemented
 data-source filtering in the `generateHashes` method. 

To prevent having to
 repeatedly filter data sources I update the configuration before it is
 passed to any ETL step. From the point of view of the ETL the excluded
 steps don't exist.