### PR TITLE
Remove risk of duplicate reactome entries.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/Reactome.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Reactome.scala
@@ -29,7 +29,7 @@ object Reactome extends LazyLogging {
     val pathways = reactomeIs("pathways").data.transform(cleanPathways)
     val edges = reactomeIs("relations").data.toDF("src", "dst")
 
-    val index = GraphNode(pathways, edges)
+    val index = GraphNode(pathways, edges).distinct
 
     logger.info("compute reactome dataset")
     val outputs = Map(


### PR DESCRIPTION
If there are more than one reactome input files in the input directory
both can be ingested creating duplicate entries in the outputs. This
commit ensures that even if that happens the outputs will be clean.

Ideally this should be prevented by specifying the correct inputs in the
 configuration file.

 Resolves opentargets/platform#1876