### PR TITLE
Updaing score calculation for gene2phenotype

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -713,7 +713,7 @@ evidences {
           'both RD and IF', 1.0,
           'strong', 1.0,
           'moderate', 0.5,
-          'limited', 0.0.1
+          'limited', 0.01
         ),
         confidence
       )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -709,11 +709,11 @@ evidences {
       score-expr: """
       element_at(
         map(
-          'possible', 0.25,
-          'probable', 0.5,
-          'confirmed', 1.0,
+          'definitive', 1.0,
           'both RD and IF', 1.0,
-          'child IF', 1.0
+          'strong', 1.0,
+          'moderate', 0.5,
+          'limited', 0.0.1
         ),
         confidence
       )


### PR DESCRIPTION
There's a new version of the Gene2Phenotype dataset, confidence values have changed to accommodate GeneCC consortium. The new scores are reflecting the weights applied for Clingen.


Current counts for each category in the evidence file:
```
+--------------+-----+
|    confidence|count|
+--------------+-----+
|    definitive| 2793|
|both RD and IF|  129|
|        strong|  849|
|       limited|  473|
+--------------+-----+
```

The `moderate` category is added as per source statements: this is future-proofing the datamodel.