### PR TITLE
Il config changes

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -744,7 +744,7 @@ evidences {
         "statisticalMethod",
         "projectId"
       ],
-      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 1e-19, 0.0, 1.0)"
+      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 2e-19, 0.0, 1.0)"
     },
     {
       id: "gene2phenotype",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -850,15 +850,6 @@ evidences {
       score-expr: "resourceScore / 100"
     },
     {
-      id: "phewas_catalog",
-      datatype-id: "genetic_association",
-      unique-fields: [
-        "diseaseFromSource",
-        "variantRsId"
-      ],
-      score-expr: "linear_rescale(studyCases, 0.0, 8800.0, 0.0, 1.0) * pvalue_linear_score(resourceScore, 0.5, 1e-25, 0.0, 1.0)"
-    },
-    {
       id: "crispr",
       score-expr: "linear_rescale(resourceScore, 41.5, 100, 0.415, 1.0)",
       unique-fields: []

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -840,7 +840,7 @@ evidences {
       score-expr: "element_at(map('Assessed', 1.0,'Not yet assessed', 0.5), confidence)"
     },
     {
-      id: "phenodigm",
+      id: "impc",
       unique-fields: [
         "diseaseFromSource",
         "biologicalModelAllelicComposition",
@@ -1021,7 +1021,7 @@ associations {
   data-sources = [
     {id: "europepmc", weight: 0.2, data-type = "literature", propagate = true},
     {id: "expression_atlas", weight: 0.2, data-type = "rna_expression", propagate = false},
-    {id: "phenodigm", weight: 0.2, data-type = "animal_model", propagate = true},
+    {id: "impc", weight: 0.2, data-type = "animal_model", propagate = true},
     {id: "progeny", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "slapenrich", weight: 0.5, data-type = "affected_pathway", propagate = true},
     {id: "sysbio", weight: 0.5, data-type = "affected_pathway", propagate = true},

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -736,7 +736,7 @@ evidences {
       score-expr: "array_min(array(1.0, pvalue_linear_score_default(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))"
     },
     {
-      id: "geneBurden",
+      id: "gene_burden",
       datatype-id: "genetic_association",
       unique-fields: [
         "ancestryId",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -744,7 +744,7 @@ evidences {
         "statisticalMethod",
         "projectId"
       ],
-      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 2e-19, 0.0, 1.0)"
+      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 2e-19, 0.5, 1.0)"
     },
     {
       id: "gene2phenotype",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -736,6 +736,17 @@ evidences {
       score-expr: "array_min(array(1.0, pvalue_linear_score_default(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))"
     },
     {
+      id: "geneBurden",
+      datatype-id: "genetic_association",
+      unique-fields: [
+        "ancestryId",
+        "diseaseFromSource"
+        "statisticalMethod",
+        "projectId"
+      ],
+      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 1e-19, 0.0, 1.0)"
+    },
+    {
       id: "gene2phenotype",
       datatype-id: "genetic_association",
       unique-fields: [


### PR DESCRIPTION
Changes to the ETL configuration to address 3 upcoming features:
- [X] Renaming of the `phenodigm` datasource to `ipmc`. I've checked and the configuration is the only place of the ETL that is affected.
- [X] Removal of the `phewas_catalog` evidence datasource config parameters.  I've checked and the configuration is the only place of the ETL that is affected.
- [X] Introduction of the `gene_burden` evidence datasource config parameters. 
    - Extra unique fields are: `ancestryId`, `diseaseFromSource`, `statisticalMethod`, `projectId`. Evidence will be unique already although `projectId` were not included (REGENERON or AZ), because at the moment this field can be inferred from the collapsing model. But I think conceptually it still makes sense to include it so that we bear that in mind and for potential future data sources.
    - @mbdebian, please pay extra attention to the p value linearisation. I've set the values by looking at [the definition of pValueLinearRescaling](https://github.com/opentargets/platform-etl-backend/blob/22ff8a6a7361a7192c57280f3814f95bc33f26d5/src/main/scala/io/opentargets/etl/backend/Evidence.scala#L23) and this is the rationale for the parameters:
        - pValue: float in the `resourceScore` column
        - inRangeMin: `2e-9`. The minimum cutoff applied to evidence to be statistically significant.
        - inRangeMax: `2e-19`. The theoretical minimum in the evidence. Practically, there is no evidence with a p value < 3.6e-14. But comparing to what this value looks like to other sources (like progeny), this is usually `inRangeMin * 1e-10`. 
        - outRangeMin: `0.5`. See below. ~`0.0`. Theoretical minimum once linearised. **Question: I am wondering if this should be 1. Instead of the minimum value, I don't know if it represents the weight of that data source in the score. My doubt comes from the fact that this is the case for progeny, where this value is 0.5.**~
        - outRangeMax: `1.0`. Theoretical maximum once linearised.