### PR TITLE
Remove PheWAS catalog from evidence processing

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -839,15 +839,6 @@ evidences {
       score-expr: "resourceScore / 100"
     },
     {
-      id: "phewas_catalog",
-      datatype-id: "genetic_association",
-      unique-fields: [
-        "diseaseFromSource",
-        "variantRsId"
-      ],
-      score-expr: "linear_rescale(studyCases, 0.0, 8800.0, 0.0, 1.0) * pvalue_linear_score(resourceScore, 0.5, 1e-25, 0.0, 1.0)"
-    },
-    {
       id: "crispr",
       score-expr: "linear_rescale(resourceScore, 41.5, 100, 0.415, 1.0)",
       unique-fields: []


### PR DESCRIPTION
Remove processing of PheWAS catalog, as this data is no longer part of the evidence dataset.