### PR TITLE
Update gene_burden linearisation

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -744,7 +744,7 @@ evidences {
         "statisticalMethod",
         "projectId"
       ],
-      score-expr: "pvalue_linear_score(resourceScore, 2e-9, 2e-19, 0.5, 1.0)"
+      score-expr: "pvalue_linear_score(resourceScore, 1e-7, 1e-17, 0.25, 1.0)"
     },
     {
       id: "gene2phenotype",


### PR DESCRIPTION
We’ve implemented a more flexible threshold for the level of statistical significance for the gene_burden evidence set (see more here https://github.com/opentargets/evidence_datasource_parsers/pull/121#commitcomment-70971329)

Therefore we want to lower the p values once they are linearised so that these less significant evidence score lower.