### PR TITLE
2629 epmc datasource parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,21 @@ The `Drug` step writes three files under the common directory specified in the `
 
 Each of these outputs includes a field `id` to allow later linkages between them.
 
+### Epmc
+
+This step was incorporated into the ETL to generate the EPMC evidence file used in the Evidence step. This was 
+originally managed by the Open Targets Data Team but moved here to reduce release friction.
+
+#### Inputs
+
+`cooccurences` files generated through the `processing` step of the [Literature pipeline](https://github.
+com/opentargets/platform-etl-literature/). 
+
+#### Configuration
+
+The flag `print-metrics` optionally logs statistics about the generated data. Data is cached before metrics are 
+generated, so it is not _too_ deleterious to performance to run this. 
+
 ### Baseline Expression
 
 The primary input sources of the baseline expression dataset are

--- a/documentation/etl_current.puml
+++ b/documentation/etl_current.puml
@@ -6,12 +6,15 @@ skinparam interface {
 skinparam artifact {
      backgroundColor<<noDependency>> orchid
      backgroundColor<<dependencies>> darkturquoise
+     backgroundColor<<literature>> yellow
  }
 ' steps
+artifact literature <<literature>>
 artifact associations <<dependencies>>
 artifact associationOTF <<dependencies>>
 artifact disease <<noDependency>>
 artifact drug <<dependencies>>
+artifact epmc <<dependencies>>
 artifact evidence <<dependencies>>
 artifact expression <<noDependency>>
 artifact go <<noDependency>>
@@ -64,4 +67,9 @@ target --> ebiSearch
 evidence --> ebiSearch
 associations --> ebiSearch
 
+epmc --> evidence
+literature --> epmc
+target --> literature
+drug --> literature
+disease --> literature
 @enduml

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -65,9 +65,9 @@ epmc {
   }
   output {
     format = "json" // to be consistent with the other Evidence files
-    path = ${common.inputs}"/evidence-files/epmc"
-    option = [
-      {k: "compression", v: "org.apache.hadoop.io.compress.GzipCodec"},
+    path = ${common.input}"/evidence-files/epmc"
+    options = [
+      {k: "compression", v: "gzip"},
     ]
   }
   excluded-target-terms = [

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -64,8 +64,11 @@ epmc {
     }
   }
   output {
-    format = ${common.output-format}
-    path = ${common.output}"/epmc-evidence"
+    format = "json" // to be consistent with the other Evidence files
+    path = ${common.inputs}"/evidence-files/epmc"
+    option = [
+      {k: "compression", v: "org.apache.hadoop.io.compress.GzipCodec"},
+    ]
   }
   excluded-target-terms = [
     "TEC",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -43,7 +43,7 @@ etl-dag {
 
 common {
   output-format = "parquet"
-  output = "gs://open-targets-pre-data-releases/21.09.4/output/etl/"${output-format}
+  output = "gs://open-targets-pre-data-releases/21.09.4/output/etl/"${common.output-format}
   output = ${?OT_ETL_OUTPUT}
 
   metadata {
@@ -56,6 +56,59 @@ common {
 
 }
 
+epmc {
+  input {
+    cooccurences {
+      format = ${common.output-format}
+      path = ${common.output}"/literature/cooccurences"
+    }
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/epmc-evidence"
+  }
+  excluded-target-terms = [
+    "TEC",
+    "TECS",
+    "Tec",
+    "tec",
+    "'",
+    "(",
+    ")",
+    "-",
+    "-S",
+    "S",
+    "S-",
+    "SS",
+    "SSS",
+    "Ss",
+    "Ss-",
+    "s",
+    "s-",
+    "ss",
+    "U3",
+    "U6",
+    "u6",
+    "SNORA70",
+    "U2",
+    "U8"
+  ]
+  # The following are the relevant sections for disease/target associations as described in PMID28587637
+  sections-of-interest = [
+    "title",
+    "abstract",
+    "intro",
+    "case",
+    "figure",
+    "table",
+    "discuss",
+    "concl",
+    "results",
+    "appendix",
+    "other",
+  ]
+  print-metrics = true
+}
 reactome {
   inputs {
     pathways {

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -7,6 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.util._
 import io.opentargets.etl.backend._
+import io.opentargets.etl.backend.Epmc
 import io.opentargets.etl.backend.drug.Drug
 import io.opentargets.etl.backend.graph.EtlDag
 import io.opentargets.etl.common.GoogleStorageHelpers
@@ -118,9 +119,7 @@ object ETL extends LazyLogging {
         implicit val ctxt: ETLSessionContext = otContext
 
         val completedSteps =
-          if (
-            otContext.configuration.sparkSettings.ignoreIfExists && otContext.configuration.sparkSettings.writeMode == "ignore"
-          )
+          if (otContext.configuration.sparkSettings.ignoreIfExists && otContext.configuration.sparkSettings.writeMode == "ignore")
             stepsWithExistingOuputs
           else Set.empty[String]
         logger.info(s"Steps already completed and not to be executed again: $completedSteps")

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -7,7 +7,6 @@ import com.typesafe.scalalogging.LazyLogging
 
 import scala.util._
 import io.opentargets.etl.backend._
-import io.opentargets.etl.backend.Epmc
 import io.opentargets.etl.backend.drug.Drug
 import io.opentargets.etl.backend.graph.EtlDag
 import io.opentargets.etl.common.GoogleStorageHelpers

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -38,6 +38,9 @@ object ETL extends LazyLogging {
       case "ebisearch" =>
         logger.info("Running EBI Search step")
         EBISearch()
+      case "epmc" =>
+        logger.info("Running EPMC step")
+        Epmc()
       case "fda" =>
         logger.info("Running OpenFDA FAERS step")
         OpenFda()

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -22,6 +22,16 @@ object Configuration extends LazyLogging {
 
   case class DataSource(id: String, weight: Double, dataType: String, propagate: Boolean)
 
+  case class EpmcInputs(cooccurences: IOResourceConfig)
+
+  case class Epmc(
+      input: EpmcInputs,
+      output: IOResourceConfig,
+      excludedTargetTerms: List[String],
+      sectionsOfInterest: List[String],
+      printMetrics: Boolean
+  )
+
   case class EvidenceEntry(
       id: String,
       uniqueFields: List[String],
@@ -311,6 +321,7 @@ object Configuration extends LazyLogging {
       expression: ExpressionSection,
       openfda: OpenfdaSection,
       ebisearch: EBISearchSection,
-      otarproject: OtarProjectSection
+      otarproject: OtarProjectSection,
+      epmc: Epmc
   )
 }

--- a/src/main/scala/io/opentargets/etl/backend/EBISearch.scala
+++ b/src/main/scala/io/opentargets/etl/backend/EBISearch.scala
@@ -2,10 +2,7 @@ package io.opentargets.etl.backend
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql._
-import org.apache.spark.sql.functions._
-import io.opentargets.etl.backend.spark.{IOResource, IOResourceConfig, IoHelpers}
-import io.opentargets.etl.backend.spark.IoHelpers
-import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import io.opentargets.etl.backend.spark.{IOResource, IoHelpers}
 import org.apache.spark.sql.SparkSession
 
 object EBISearch extends LazyLogging {

--- a/src/main/scala/io/opentargets/etl/backend/Epmc.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Epmc.scala
@@ -1,0 +1,127 @@
+package io.opentargets.etl.backend
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.spark.{IOResource, IoHelpers}
+import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import org.apache.spark.sql.functions.{
+  coalesce,
+  col,
+  collect_set,
+  length,
+  struct,
+  sum,
+  trim,
+  when,
+  size,
+  lit
+}
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.{DataFrame, SparkSession}
+
+object Epmc extends LazyLogging {
+
+  def apply()(implicit context: ETLSessionContext): IOResources = {
+    implicit val ss: SparkSession = context.sparkSession
+
+    logger.info("Prepare EPMC evidence")
+
+    val conf = context.configuration.epmc
+
+    val inputDataFrames = IoHelpers.readFrom(
+      Map(
+        "cooccurences" -> conf.input.cooccurences
+      )
+    )
+
+    val cooccurencesDf = compute(
+      inputDataFrames("cooccurences").data,
+      conf.excludedTargetTerms,
+      conf.sectionsOfInterest
+    )
+
+    val evidence = cooccurencesDf
+      .withColumn("datasourceId", lit("europepmc"))
+      .withColumn("datatypeId", lit("literature"))
+      .select(
+        "datasourceId",
+        "datatypeId",
+        "targetFromSourceId",
+        "diseaseFromSourceMappedId",
+        "resourceScore",
+        "literature",
+        "textMiningSentences",
+        "pmcIds"
+      )
+      .cache()
+
+    logger.info("EPMC disease target evidence saved.")
+    if (conf.printMetrics) {
+      logger.info(s"Number of evidence: ${cooccurencesDf.count()}")
+      logger.info(
+        s"Number of publications: ${cooccurencesDf.select(col("publicationIdentifier")).count()}"
+      )
+      logger.info(
+        s"Number of publications without pubmed ID: ${cooccurencesDf
+          .filter(col("publicationIdentifier").contains("PMC"))
+          .select("publicationIdentifier")
+          .distinct
+          .count()}"
+      )
+      logger.info(
+        s"Number of targets: ${evidence.select(col("targetFromSourceId")).distinct.count()}"
+      )
+      logger.info(
+        s"Number of diseases: ${evidence.select(col("diseaseFromSourceMappedId")).distinct.count()}"
+      )
+      logger.info(
+        f"Number of associations: ${evidence.select(col("diseaseFromSourceMappedId"), col("targetFromSourceId")).dropDuplicates().count()}"
+      )
+    }
+
+    logger.info(s"Write EMPC data to ${conf.output.path}")
+    val dataframesToSave = Map(
+      // coalesce to maintain logic previously used by datateam. A single file is used for metrics calculations.
+      "epmc" -> IOResource(evidence.coalesce(1), conf.output)
+    )
+
+    IoHelpers.writeTo(dataframesToSave)
+  }
+
+  private def compute(
+      df: DataFrame,
+      excludedTerms: List[String],
+      sectionOfInterest: List[String]
+  ): DataFrame = {
+    df.filter(col("section").isin(sectionOfInterest: _*))
+      .withColumn("pmid", trim(col("pmid") cast StringType))
+      .withColumn("publicationIdentifier", coalesce(col("pmid"), col("pmcid")))
+      .filter(
+        col("type") === "GP-DS" &&
+          col("isMapped") &&
+          col("publicationIdentifier").isNotNull &&
+          length(col("text")) < 600 && !col("label1").isin(excludedTerms: _*)
+      )
+      .withColumnRenamed("keywordId1", "targetFromSourceId")
+      .withColumnRenamed("keywordId2", "diseaseFromSourceMappedId")
+      .groupBy("publicationIdentifier", "targetFromSourceId", "diseaseFromSourceMappedId")
+      .agg(
+        collect_set(col("pmcid")).alias("pmcIds"),
+        collect_set(col("pmid")).alias("literature"),
+        collect_set(
+          struct(
+            col("text"),
+            col("start1").alias("tStart"),
+            col("end1").alias("tEnd"),
+            col("start2").alias("dStart"),
+            col("end2").alias("dEnd"),
+            col("section")
+          )
+        ).alias("textMiningSentences"),
+        sum(col("evidence_score")).alias("resourceScore")
+      )
+      .withColumn("pmcIds", when(size(col("pmcIds")) =!= 0, col("pmcIds")))
+      .filter(col("resourceScore") > 1)
+      .cache()
+  }
+
+}


### PR DESCRIPTION
Resolves opentargets/platform#2629

Moves the logic the data team was using into the ETL to make the release process faster: we don't need to circle back to them for input after we run literature now, we can do it ourselves. 