### PR TITLE
ETL configuration minimisation

### DIFF
--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,9 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// Reactome --- //
-reactome.inputs.pathways.path = ${common.input}"/reactome-inputs/ReactomePathways.txt"
-reactome.inputs.relations.path = ${common.input}"/reactome-inputs/ReactomePathwaysRelation.txt"
 // Target --- //
 target.input.chemical-probes.path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json"
 target.input.ensembl.path = ${common.input}"/target-inputs/ensembl/homo_sapiens.jsonl"

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -5,23 +5,3 @@ chembl_version = "30"
 ensembl_version = "106"
 evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
 // --- END - UPDATE THIS --- //
-
-// --- NO NEED TO CHANGE ANYTHING HERE --- //
-etl-dag.resolve = false
-etl-dag.steps = [
-                    {step: "disease", dependencies: []},
-                    {step: "reactome", dependencies: []},
-                    {step: "expression", dependencies: []},
-                    {step: "go", dependencies: []},
-                    {step: "target", dependencies: ["reactome"]},
-                    {step: "interaction", dependencies: ["target"]},
-                    {step: "targetValidation", dependencies: ["target"]},
-                    {step: "evidence", dependencies: ["disease", "target"]},
-                    {step: "association", dependencies: ["evidence", "disease"]},
-                    {step: "associationOTF", dependencies: ["evidence", "target", "disease", "reactome"]},
-                    {step: "search", dependencies: ["target", "drug", "evidence", "association", "disease"]},
-                    {step: "drug", dependencies: ["target", "evidence"]},
-                    {step: "knownDrug", dependencies: ["target", "disease", "drug", "evidence"]},
-                    {step: "ebisearch", dependencies: ["target", "disease", "evidence", "association"]},
-                    {step: "fda", dependencies: ["drug"]},
-                  ]

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -4,11 +4,28 @@ spark-settings.write-mode = "ignore"
 data_version = "development"
 chembl_version = "30"
 ensembl_version = "106"
-evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation", "otar"]
+evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
 // --- END - UPDATE THIS --- //
 
 // --- NO NEED TO CHANGE ANYTHING HERE --- //
 etl-dag.resolve = false
+etl-dag.steps = [
+                    {step: "disease", dependencies: []},
+                    {step: "reactome", dependencies: []},
+                    {step: "expression", dependencies: []},
+                    {step: "go", dependencies: []},
+                    {step: "target", dependencies: ["reactome"]},
+                    {step: "interaction", dependencies: ["target"]},
+                    {step: "targetValidation", dependencies: ["target"]},
+                    {step: "evidence", dependencies: ["disease", "target"]},
+                    {step: "association", dependencies: ["evidence", "disease"]},
+                    {step: "associationOTF", dependencies: ["evidence", "target", "disease", "reactome"]},
+                    {step: "search", dependencies: ["target", "drug", "evidence", "association", "disease"]},
+                    {step: "drug", dependencies: ["target", "evidence"]},
+                    {step: "knownDrug", dependencies: ["target", "disease", "drug", "evidence"]},
+                    {step: "ebisearch", dependencies: ["target", "disease", "evidence", "association"]},
+                    {step: "fda", dependencies: ["drug"]},
+                  ]
 
 // Expression --- //
 expression.binned.path = ${common.input}"/expression-inputs/baseline_expression_binned.tsv"

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -4,7 +4,7 @@ spark-settings.write-mode = "ignore"
 data_version = "development"
 chembl_version = "30"
 ensembl_version = "106"
-evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
+evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation", "otar"]
 // --- END - UPDATE THIS --- //
 
 // --- NO NEED TO CHANGE ANYTHING HERE --- //

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -1,0 +1,75 @@
+// --- UPDATE THIS --- //
+spark-settings.write-mode = "ignore"
+// common.output-format = "json"
+data_version = "22.06.1"
+chembl_version = "30"
+ensembl_version = "106"
+evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
+// --- END - UPDATE THIS --- //
+
+// --- NO NEED TO CHANGE ANYTHING HERE --- //
+etl-dag.resolve = false
+
+// Expression --- //
+expression.binned.path = ${common.input}"/expression-inputs/baseline_expression_binned.tsv"
+expression.rna.path = ${common.input}"/expression-inputs/baseline_expression_counts.tsv"
+expression.zscore.path = ${common.input}"/expression-inputs/baseline_expression_zscore_binned.tsv"
+expression.exprhierarchy.path = ${common.input}"/expression-inputs/expression_hierarchy_curation.tsv"
+expression.tissues.path = ${common.input}"/expression-inputs/normal_tissue.tsv.gz"
+expression.efomap.path = ${common.input}"/expression-inputs/tissue-translation-map.json"
+// OpenFDA --- //
+openfda.meddra.meddra-preferred-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
+openfda.meddra-low-level-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"
+// GO --- //
+gene-ontology.go-input.path = ${common.input}"/gene-ontology-inputs/go.obo"
+// Interactions --- //
+interactions.strings.path = ${common.input}"/interactions-inputs/9606.protein.links.full_w_homology.v11.5.txt.gz"
+interactions.humanmapping.path = ${common.input}"/interactions-inputs/HUMAN_9606_idmapping.dat.gz"
+interactions.ensproteins.path = ${common.input}"/interactions-inputs/Homo_sapiens.GRCh38.chr.gtf.gz"
+interactions.intact.path = ${common.input}"/interactions-inputs/intact-interactors.json"
+interactions.rnacentral.path = ${common.input}"/interactions-inputs/rna_central_ensembl.tsv"
+// Disease --- //
+disease.hpo-phenotype.path = ${common.input}"/ontology-inputs/hpo-phenotypes.jsonl"
+disease.efo-ontology.path = ${common.input}"/ontology-inputs/ontology-efo-v3.42.0.jsonl"
+disease.hpo-ontology.path = ${common.input}"/ontology-inputs/ontology-hpo.jsonl"
+disease.mondo-ontology.path = ${common.input}"/ontology-inputs/ontology-mondo.jsonl"
+// Reactome --- //
+reactome.inputs.pathways.path = ${common.input}"/reactome-inputs/ReactomePathways.txt"
+reactome.inputs.relations.path = ${common.input}"/reactome-inputs/ReactomePathwaysRelation.txt"
+// Target --- //
+target.input.chemical-probes.path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json"
+target.input.ensembl.path = ${common.input}"/target-inputs/ensembl/homo_sapiens.jsonl"
+target.input.hgnc.path = ${common.input}"/target-inputs/genenames/hgnc_complete_set.json"
+target.input.genetic-constraints.path = ${common.input}"/target-inputs/gnomad/gnomad_lof_by_gene.txt.gz"
+target.input.gene-ontology-rna-lookup.path = ${common.input}"/target-inputs/go/ensembl.tsv"
+target.input.gene-ontology.path = ${common.input}"/target-inputs/go/goa_human.gaf.gz"
+target.input.gene-ontology-eco.path = ${common.input}"/target-inputs/go/goa_human_eco.gpa.gz"
+target.input.gene-ontology-rna.path = ${common.input}"/target-inputs/go/goa_human_rna.gaf.gz"
+target.input.hallmarks.path = ${common.input}"/target-inputs/hallmarks/cosmic-hallmarks.tsv.gz"
+target.input.homology-dictionary.path = ${common.input}"/target-inputs/homologue/species_EnsemblVertebrates.txt"
+target.input.homology-coding-proteins.path = ${common.input}"/target-inputs/homologue/c*.tsv.gz"
+target.input.homology-gene-dictionary.path = ${common.input}"/target-inputs/homologue/"${ensembl_version}"/"${ensembl_version}"-*.tsv"
+target.input.hpa.path = ${common.input}"/target-inputs/hpa/subcellular_location.tsv.gz"
+target.input.hpa-sl-ontology.path = ${common.input}"/target-inputs/hpa/subcellular_locations_ssl.tsv"
+target.input.ncbi.path = ${common.input}"/target-inputs/ncbi/Homo_sapiens.gene_info.gz"
+target.input.ps-essentiality-matrix.path = ${common.input}"/target-inputs/project-scores/04_binaryDepScores.tsv"
+target.input.ps-gene-identifier.path = ${common.input}"/target-inputs/project-scores/gene_identifiers_latest.csv.gz"
+target.input.reactome-pathways.path = ${common.input}"/target-inputs/reactome/Ensembl2Reactome.txt"
+target.input.safety-adverse-event.path = ${common.input}"/target-inputs/safety/adverse_events/adverse_event_safety.json"
+target.input.safety-safety-risk.path = ${common.input}"/target-inputs/safety/safety_risk/sr.json"
+target.input.safety-toxicity.path = ${common.input}"/target-inputs/safety/toxcast/ToxCast.tsv"
+target.input.tep.path = ${common.input}"/target-inputs/tep/tep.json.gz"
+target.input.tractability.path = ${common.input}"/target-inputs/tractability/tractability.tsv"
+target.input.uniprot.path = ${common.input}"/target-inputs/uniprot/uniprot.txt.gz"
+target.input.uniprot-ssl.path = ${common.input}"/target-inputs/uniprot/uniprot-ssl.tsv.gz"
+// Mouse Phenotypes Inputs --- //
+target-validation.inputs = [
+  {
+    name = "mousePhenotypes"
+    id-column = "targetFromSourceId"
+    data = {
+      format = "json"
+      path = ${common.input}"/mouse-phenotypes-inputs/mouse_phenotypes.json.gz"
+    }
+  }
+]

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,8 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// GO --- //
-gene-ontology.go-input.path = ${common.input}"/gene-ontology-inputs/go.obo"
 // Interactions --- //
 interactions.strings.path = ${common.input}"/interactions-inputs/9606.protein.links.full_w_homology.v11.5.txt.gz"
 interactions.humanmapping.path = ${common.input}"/interactions-inputs/HUMAN_9606_idmapping.dat.gz"

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -1,7 +1,7 @@
 // --- UPDATE THIS --- //
 spark-settings.write-mode = "ignore"
 // common.output-format = "json"
-data_version = "22.06.1"
+data_version = "development"
 chembl_version = "30"
 ensembl_version = "106"
 evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,32 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// Target --- //
-target.input.chemical-probes.path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json"
-target.input.ensembl.path = ${common.input}"/target-inputs/ensembl/homo_sapiens.jsonl"
-target.input.hgnc.path = ${common.input}"/target-inputs/genenames/hgnc_complete_set.json"
-target.input.genetic-constraints.path = ${common.input}"/target-inputs/gnomad/gnomad_lof_by_gene.txt.gz"
-target.input.gene-ontology-rna-lookup.path = ${common.input}"/target-inputs/go/ensembl.tsv"
-target.input.gene-ontology.path = ${common.input}"/target-inputs/go/goa_human.gaf.gz"
-target.input.gene-ontology-eco.path = ${common.input}"/target-inputs/go/goa_human_eco.gpa.gz"
-target.input.gene-ontology-rna.path = ${common.input}"/target-inputs/go/goa_human_rna.gaf.gz"
-target.input.hallmarks.path = ${common.input}"/target-inputs/hallmarks/cosmic-hallmarks.tsv.gz"
-target.input.homology-dictionary.path = ${common.input}"/target-inputs/homologue/species_EnsemblVertebrates.txt"
-target.input.homology-coding-proteins.path = ${common.input}"/target-inputs/homologue/c*.tsv.gz"
-target.input.homology-gene-dictionary.path = ${common.input}"/target-inputs/homologue/"${ensembl_version}"/"${ensembl_version}"-*.tsv"
-target.input.hpa.path = ${common.input}"/target-inputs/hpa/subcellular_location.tsv.gz"
-target.input.hpa-sl-ontology.path = ${common.input}"/target-inputs/hpa/subcellular_locations_ssl.tsv"
-target.input.ncbi.path = ${common.input}"/target-inputs/ncbi/Homo_sapiens.gene_info.gz"
-target.input.ps-essentiality-matrix.path = ${common.input}"/target-inputs/project-scores/04_binaryDepScores.tsv"
-target.input.ps-gene-identifier.path = ${common.input}"/target-inputs/project-scores/gene_identifiers_latest.csv.gz"
-target.input.reactome-pathways.path = ${common.input}"/target-inputs/reactome/Ensembl2Reactome.txt"
-target.input.safety-adverse-event.path = ${common.input}"/target-inputs/safety/adverse_events/adverse_event_safety.json"
-target.input.safety-safety-risk.path = ${common.input}"/target-inputs/safety/safety_risk/sr.json"
-target.input.safety-toxicity.path = ${common.input}"/target-inputs/safety/toxcast/ToxCast.tsv"
-target.input.tep.path = ${common.input}"/target-inputs/tep/tep.json.gz"
-target.input.tractability.path = ${common.input}"/target-inputs/tractability/tractability.tsv"
-target.input.uniprot.path = ${common.input}"/target-inputs/uniprot/uniprot.txt.gz"
-target.input.uniprot-ssl.path = ${common.input}"/target-inputs/uniprot/uniprot-ssl.tsv.gz"
 // Mouse Phenotypes Inputs --- //
 target-validation.inputs = [
   {

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -1,6 +1,5 @@
 // --- UPDATE THIS --- //
 spark-settings.write-mode = "ignore"
-// common.output-format = "json"
 data_version = "development"
 chembl_version = "30"
 ensembl_version = "106"
@@ -26,15 +25,3 @@ etl-dag.steps = [
                     {step: "ebisearch", dependencies: ["target", "disease", "evidence", "association"]},
                     {step: "fda", dependencies: ["drug"]},
                   ]
-
-// Mouse Phenotypes Inputs --- //
-target-validation.inputs = [
-  {
-    name = "mousePhenotypes"
-    id-column = "targetFromSourceId"
-    data = {
-      format = "json"
-      path = ${common.input}"/mouse-phenotypes-inputs/mouse_phenotypes.json.gz"
-    }
-  }
-]

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,11 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// Disease --- //
-disease.hpo-phenotype.path = ${common.input}"/ontology-inputs/hpo-phenotypes.jsonl"
-disease.efo-ontology.path = ${common.input}"/ontology-inputs/ontology-efo-v3.42.0.jsonl"
-disease.hpo-ontology.path = ${common.input}"/ontology-inputs/ontology-hpo.jsonl"
-disease.mondo-ontology.path = ${common.input}"/ontology-inputs/ontology-mondo.jsonl"
 // Reactome --- //
 reactome.inputs.pathways.path = ${common.input}"/reactome-inputs/ReactomePathways.txt"
 reactome.inputs.relations.path = ${common.input}"/reactome-inputs/ReactomePathwaysRelation.txt"

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,9 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// OpenFDA --- //
-openfda.meddra.meddra-preferred-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
-openfda.meddra-low-level-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"
 // GO --- //
 gene-ontology.go-input.path = ${common.input}"/gene-ontology-inputs/go.obo"
 // Interactions --- //

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,12 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// Interactions --- //
-interactions.strings.path = ${common.input}"/interactions-inputs/9606.protein.links.full_w_homology.v11.5.txt.gz"
-interactions.humanmapping.path = ${common.input}"/interactions-inputs/HUMAN_9606_idmapping.dat.gz"
-interactions.ensproteins.path = ${common.input}"/interactions-inputs/Homo_sapiens.GRCh38.chr.gtf.gz"
-interactions.intact.path = ${common.input}"/interactions-inputs/intact-interactors.json"
-interactions.rnacentral.path = ${common.input}"/interactions-inputs/rna_central_ensembl.tsv"
 // Disease --- //
 disease.hpo-phenotype.path = ${common.input}"/ontology-inputs/hpo-phenotypes.jsonl"
 disease.efo-ontology.path = ${common.input}"/ontology-inputs/ontology-efo-v3.42.0.jsonl"

--- a/configuration/2022/22_09_platform.conf
+++ b/configuration/2022/22_09_platform.conf
@@ -27,13 +27,6 @@ etl-dag.steps = [
                     {step: "fda", dependencies: ["drug"]},
                   ]
 
-// Expression --- //
-expression.binned.path = ${common.input}"/expression-inputs/baseline_expression_binned.tsv"
-expression.rna.path = ${common.input}"/expression-inputs/baseline_expression_counts.tsv"
-expression.zscore.path = ${common.input}"/expression-inputs/baseline_expression_zscore_binned.tsv"
-expression.exprhierarchy.path = ${common.input}"/expression-inputs/expression_hierarchy_curation.tsv"
-expression.tissues.path = ${common.input}"/expression-inputs/normal_tissue.tsv.gz"
-expression.efomap.path = ${common.input}"/expression-inputs/tissue-translation-map.json"
 // OpenFDA --- //
 openfda.meddra.meddra-preferred-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/pt.asc"
 openfda.meddra-low-level-terms.path = "gs://open-targets-data-releases-private/meddra/meddra23.1/MedAscii/llt.asc"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -267,15 +267,15 @@ target {
     chembl = ${drug.chembl-target}
     chemical-probes = {
       format = "json"
-      path = ${common.input}"/target-inputs/chemicalprobes-2021-09-17.json"
+      path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json"
     }
     ensembl {
       format = "json"
-      path = ${common.input}"/target-inputs/ensembl/homo_sapiens_104.jsonl"
+      path = ${common.input}"/target-inputs/ensembl/homo_sapiens.jsonl"
     }
     genetic-constraints = {
       format = "csv"
-      path = ${common.input}"/target-inputs/gnomad/gnomad_lof_by_gene.csv"
+      path = ${common.input}"/target-inputs/gnomad/gnomad_lof_by_gene.txt.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -315,7 +315,7 @@ target {
     }
     hallmarks {
       format = "csv"
-      path = ${common.input}"/target-inputs/hallmarks/cosmic-hallmarks-*.tsv.gz"
+      path = ${common.input}"/target-inputs/hallmarks/cosmic-hallmarks.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -323,7 +323,7 @@ target {
     }
     hgnc {
       format = "json"
-      path = ${common.input}"/target-inputs/hgnc_complete_set-2021-09-22.json"
+      path = ${common.input}"/target-inputs/genenames/hgnc_complete_set.json"
     },
     homology-dictionary {
       format = "csv"
@@ -335,7 +335,7 @@ target {
     }
     homology-coding-proteins {
       format = "csv"
-      path = ${common.input}"/target-inputs/homologue/104/*.tsv.gz"
+      path = ${common.input}"/target-inputs/homologue/c*.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -343,14 +343,14 @@ target {
     }
     homology-gene-dictionary {
       format = "csv"
-      path = ${common.input}"/target-inputs/homologue/104/104-*.tsv"
+      path = ${common.input}"/target-inputs/homologue/"${ensembl_version}"/"${ensembl_version}"-*.tsv"
       options = [
         {k: "sep", v: "\\t"}
       ]
     }
     hpa {
       format = "csv"
-      path = ${common.input}"/target-inputs/hpa/subcellular_location.tsv"
+      path = ${common.input}"/target-inputs/hpa/subcellular_location.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -358,7 +358,7 @@ target {
     }
     hpa-sl-ontology {
       format = "csv"
-      path = ${common.input}"/target-inputs/hpa/subcellular_locations_ssl-2021-08-19.tsv"
+      path = ${common.input}"/target-inputs/hpa/subcellular_locations_ssl.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -374,14 +374,14 @@ target {
     }
     ps-gene-identifier {
       format = "csv"
-      path = ${common.input}"/target-inputs/projectScores/gene_identifiers_latest.csv.gz"
+      path = ${common.input}"/target-inputs/project-scores/gene_identifiers_latest.csv.gz"
       options = [
         {k: "header", v: true}
       ]
     }
     ps-essentiality-matrix {
       format = "csv"
-      path = ${common.input}"/target-inputs/projectScores/04_binaryDepScores.tsv"
+      path = ${common.input}"/target-inputs/project-scores/04_binaryDepScores.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -400,7 +400,7 @@ target {
     }
     safety-toxicity {
       format = "csv"
-      path = ${common.input}"/target-inputs/safety/ToxCast_2021-08-17.tsv"
+      path = ${common.input}"/target-inputs/safety/toxcast/ToxCast.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -408,19 +408,19 @@ target {
     }
     safety-adverse-event {
       format = "json"
-      path = ${common.input}"/target-inputs/safety/ae_2021-11-03.json"
+      path = ${common.input}"/target-inputs/safety/adverse_events/adverse_event_safety.json"
     }
     safety-safety-risk {
       format = "json"
-      path = ${common.input}"/target-inputs/safety/sr_safety/sr-2021-11-03.json"
+      path = ${common.input}"/target-inputs/safety/safety_risk/sr.json"
     }
     tep {
       format = "json"
-      path = ${common.input}"/target-inputs/tep-2021-09-10.json.gz"
+      path = ${common.input}"/target-inputs/tep/tep.json.gz"
     },
     tractability = {
       format = "csv"
-      path = ${common.input}"/target-inputs/tractability/tracta*tsv"
+      path = ${common.input}"/target-inputs/tractability/tractability.tsv"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}
@@ -428,11 +428,11 @@ target {
     }
     uniprot {
       format = "txt"
-      path = ${common.input}"/target-inputs/uniprot-2021-09-22.txt"
+      path = ${common.input}"/target-inputs/uniprot/uniprot.txt.gz"
     }
     uniprot-ssl {
       format = "csv"
-      path = ${common.input}"/target-inputs/uniport/uniport-ssl*.tsv"
+      path = ${common.input}"/target-inputs/uniprot/uniprot-ssl.tsv.gz"
       options = [
         {k: "sep", v: "\\t"}
         {k: "header", v: true}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -469,7 +469,7 @@ target-validation {
       id-column = "targetFromSourceId"
       data = {
         format = "json"
-        path = ${common.input}"/mouse-phenotypes-inputs/mousePhenotypes-2021-11-02.json.gz"
+        path = ${common.input}"/mouse-phenotypes-inputs/mouse_phenotypes.json.gz"
       }
     }
   ]

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,5 +1,11 @@
 spark-uri = null
 
+// --- Release baseline parameters --- //
+data_version = "YY.MM.n"
+chembl_version = "XX"
+ensembl_version = "YYY"
+// --- END --- Release baseline parameters --- //
+
 spark-settings {
   // Specifies the behavior when data or table already exists. Options include:
   //   overwrite: overwrite the existing data.
@@ -43,7 +49,7 @@ etl-dag {
 
 common {
   output-format = "parquet"
-  output = "gs://open-targets-pre-data-releases/21.09.4/output/etl/"${common.output-format}
+  output = "gs://open-targets-pre-data-releases/"${data_version}"/output/etl/"${common.output-format}
   output = ${?OT_ETL_OUTPUT}
 
   metadata {
@@ -51,7 +57,7 @@ common {
     path = ${common.output}"/metadata/"
   }
 
-  input = "gs://open-targets-pre-data-releases/21.09.4/input"
+  input = "gs://open-targets-pre-data-releases/"${data_version}"/input"
   error = ${common.output}"/errors/"
   additional-outputs = [ "json" ]
 
@@ -517,23 +523,23 @@ disease {
 drug {
   chembl-molecule {
     format = "json"
-    path = ${common.input}"/chembl-inputs/chembl_29_molecule-2021-09-16.jsonl"
+    path = ${common.input}"/chembl-inputs/chembl_"${chembl_version}"_molecule.jsonl"
   }
   chembl-indication {
     format = "json"
-    path = ${common.input}"/chembl-inputs/chembl_29_drug_indication-2021-09-16.jsonl"
+    path = ${common.input}"/chembl-inputs/chembl_"${chembl_version}"_drug_indication.jsonl"
   }
   chembl-mechanism {
     format = "json"
-    path = ${common.input}"/chembl-inputs/chembl_29_mechanism-2021-09-16.jsonl"
+    path = ${common.input}"/chembl-inputs/chembl_"${chembl_version}"_mechanism.jsonl"
   }
   chembl-target {
     format = "json"
-    path = ${common.input}"/chembl-inputs/chembl_29_target-2021-09-16.jsonl"
+    path = ${common.input}"/chembl-inputs/chembl_"${chembl_version}"_target.jsonl"
   }
   chembl-warning {
     format = "json"
-    path = ${common.input}"/chembl-inputs/chembl_29_drug_warning-2021-09-16.jsonl"
+    path = ${common.input}"/chembl-inputs/chembl_"${chembl_version}"_drug_warning.jsonl"
   }
   disease-etl = ${disease.outputs.diseases}
   target-etl {
@@ -543,7 +549,7 @@ drug {
   evidence-etl = ${evidences.outputs.succeeded}
   drugbank-to-chembl {
     format = "csv"
-    path = ${common.input}"/chembl-inputs/drugbank-2020-06-01.csv.gz"
+    path = ${common.input}"/chembl-inputs/drugbank.csv.gz"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "true"}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -149,7 +149,7 @@ reactome {
 expression {
   rna {
     format = "csv"
-    path = ${common.input}"/expression-inputs/baseline_expression_counts-2020-05-07.tsv"
+    path = ${common.input}"/expression-inputs/baseline_expression_counts.tsv"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "true"}
@@ -158,7 +158,7 @@ expression {
   }
   binned {
     format = "csv"
-    path = ${common.input}"/expression-inputs/baseline_expression_binned-2020-05-07.tsv"
+    path = ${common.input}"/expression-inputs/baseline_expression_binned.tsv"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "true"}
@@ -167,7 +167,7 @@ expression {
   }
   zscore {
     format = "csv"
-    path = ${common.input}"/expression-inputs/baseline_expression_zscore_binned-2020-05-07.tsv"
+    path = ${common.input}"/expression-inputs/baseline_expression_zscore_binned.tsv"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "true"}
@@ -176,7 +176,7 @@ expression {
   }
   exprhierarchy {
     format = "csv"
-    path = ${common.input}"/expression-inputs/expression_hierarchy_curation-2021-09-22.tsv"
+    path = ${common.input}"/expression-inputs/expression_hierarchy_curation.tsv"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "false"}
@@ -185,11 +185,11 @@ expression {
   }
   efomap {
     format = "json"
-    path = ${common.input}"/expression-inputs/map_with_efos-2021-09-22.json"
+    path = ${common.input}"/expression-inputs/tissue-translation-map.json"
   }
   tissues {
     format = "csv"
-    path = ${common.input}"/expression-inputs/normal_tissue-2021-09-22.tsv"
+    path = ${common.input}"/expression-inputs/normal_tissue.tsv.gz"
     options = [
       {k: "sep", v: "\\t"},
       {k: "header", v: "true"}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -490,7 +490,7 @@ target-validation {
 disease {
   efo-ontology {
     format = "json"
-    path = ${common.input}"/ontology-inputs/ontology-efo-v3.34.0.jsonl"
+    path = ${common.input}"/ontology-inputs/ontology-efo-v3.42.0.jsonl"
   }
   hpo-ontology {
     format = "json"
@@ -502,7 +502,7 @@ disease {
   }
   hpo-phenotype {
     format = "json"
-    path = ${common.input}"/ontology-inputs/hpo-phenotypes-2021-09-22.jsonl"
+    path = ${common.input}"/ontology-inputs/hpo-phenotypes.jsonl"
   }
   outputs = {
     diseases {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1019,7 +1019,7 @@ evidences {
 gene-ontology {
   go-input = {
     format = "csv"
-    path = ${common.input}"/target-inputs/go/go.obo"
+    path = ${common.input}"/gene-ontology-inputs/go.obo"
   }
   output {
     format = ${common.output-format}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ reactome {
   inputs {
     pathways {
       format = "csv"
-      path = ${common.input}"/reactome-inputs/ReactomePathways-2021-09-22.txt"
+      path = ${common.input}"/reactome-inputs/ReactomePathways.txt"
       options = [
         {k: "sep", v: "\\t"},
         {k: "header", v: "false"}
@@ -132,7 +132,7 @@ reactome {
     }
     relations {
       format = "csv"
-      path = ${common.input}"/reactome-inputs/ReactomePathwaysRelation-2021-09-22.txt"
+      path = ${common.input}"/reactome-inputs/ReactomePathwaysRelation.txt"
       options = [
         {k: "sep", v: "\\t"},
         {k: "header", v: "false"}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -235,11 +235,11 @@ interactions {
   }
   intact {
     format = "json"
-    path = ${common.input}"/interactions-inputs/intact-interactors-2021-09-15.json"
+    path = ${common.input}"/interactions-inputs/intact-interactors.json"
   }
   strings {
     format = "csv"
-    path = ${common.input}"/interactions-inputs/9606.protein.links.full_w_homology.v11.0.txt.gz"
+    path = ${common.input}"/interactions-inputs/9606.protein.links.full_w_homology.v11.5.txt.gz"
     options = [
       {k: "sep", v: " "},
       {k: "header", v: "true"}


### PR DESCRIPTION
This PR minimizes the configuration required for running the ETL backend on a release dataset, as part of the Open Targets Platform release streamlining process.

An example of the new release configuration file has been included at 
```
configuration/2022/22_09_platform.conf
```

That will be use as the baseline for the coming Open Targets Platform release.

It solves opentargets/issues#2647

If you'd like to run it, please remember that it will complain about missing _otar.tsv_ file, so that step should be excluded when running it.

