### PR TITLE
Update step execution to fail when step is unknown.

### DIFF
--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -68,7 +68,7 @@ object ETL extends LazyLogging {
       case "targetvalidation" =>
         logger.info("run step targetValidation")
         TargetValidation()
-      case _ => logger.warn(s"step $step is unknown so nothing to execute")
+      case _ => throw new IllegalArgumentException(s"step $step is unknown.")
     }
     logger.info(s"finished to run step ($step)")
   }

--- a/src/test/scala/io/opentargets/etl/EtlTest.scala
+++ b/src/test/scala/io/opentargets/etl/EtlTest.scala
@@ -1,0 +1,12 @@
+package io.opentargets.etl
+
+import io.opentargets.etl.backend.ETLSessionContext
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+
+class EtlTest extends AnyFlatSpec with MockFactory {
+  "The pipeline" should "fail given an unknown step" in {
+    val esc: ETLSessionContext = mock[ETLSessionContext]
+    assertThrows[IllegalArgumentException](ETL.applySingleStep("foo")(esc))
+  }
+}


### PR DESCRIPTION
When steps are included as part of a workflow we want to break when an
unknown step is called rather than success but with no output or warning
.
