### PR TITLE
Ensure no duplicate targets are introduced by canonical transcripts.

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Ensembl.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Ensembl.scala
@@ -67,7 +67,14 @@ object Ensembl extends LazyLogging {
       dataFrame: DataFrame,
       canonicalTranscripts: Dataset[GeneAndCanonicalTranscript]
   ): DataFrame =
-    dataFrame.join(canonicalTranscripts, Seq("id"), "left_outer")
+    dataFrame
+      .join(
+        canonicalTranscripts.withColumnRenamed("id", "ctId"),
+        col("id") === col("ctId")
+          && col("chromosome") === col("canonicalTranscript.chromosome"),
+        "left_outer"
+      )
+      .drop("ctId")
 
   /** Adds canonicalExons to dataframe as an array of Array(e1_start, e1_end, ..., en_start,
     * en_end).


### PR DESCRIPTION
In the 22.09 release there were ~40 duplicate targets introduced. This
was because genecode assigned some transcripts to two separate genes.
This filter ensures that the canonical transcript is only applied to to
the Ensembl target and does not introduce a shadow duplicate.

Resolves opentargets/platform#2732
