### PR TITLE
Update Metadata generation.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -54,8 +54,11 @@ common {
   output = ${?OT_ETL_OUTPUT}
 
   metadata {
-    format = "json"
-    path = ${common.output}"/metadata/"
+    write-mode = "append"
+    output {
+      format = "json"
+      path = ${common.output-base_path}"/metadata/"
+    }
   }
 
   input = "gs://open-targets-pre-data-releases/"${data_version}"/input"

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -151,13 +151,15 @@ object Configuration extends LazyLogging {
       output: IOResourceConfig
   )
 
+  case class MetadataConfig(writeMode: String, output: IOResourceConfig)
+
   case class Common(
       input: String,
       output: String,
       error: String,
       outputFormat: String,
       additionalOutputs: List[String],
-      metadata: IOResourceConfig
+      metadata: MetadataConfig
   )
 
   case class KnownDrugsInputsSection(

--- a/src/main/scala/io/opentargets/etl/backend/spark/MetadataHelper.scala
+++ b/src/main/scala/io/opentargets/etl/backend/spark/MetadataHelper.scala
@@ -1,0 +1,56 @@
+package io.opentargets.etl.backend.spark
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.ETLSessionContext
+import io.opentargets.etl.backend.spark.MetadataHelper.getContentPath
+import org.apache.spark.sql.functions.current_timestamp
+
+trait MetadataWriter {
+  def create(ioResource: IOResource): IOResource
+  def write(ioResource: IOResource): Unit
+}
+
+object MetadataHelper {
+
+  /** For the metadata we want to discard the common output path, so
+    * `gs://open-targets-pre-data-releases/22.11/output/etl/parquet/reactome` becomes `/reactome`
+    * and `gs://open-targets-pre-data-releases/22.11/output/etl/parquet/fda/adverseTargetReactions`
+    * becomes `/fda/adverseTargetReactions`
+    */
+  private def getContentPath(path: String, outputFormat: String): String =
+    path.split(outputFormat).last
+}
+
+class MetadataHelper(context: ETLSessionContext) extends MetadataWriter with LazyLogging {
+  private val metadataSettings = context.configuration.common.metadata
+
+  private def prepareMetadata(ioResource: IOResource): Metadata = {
+    val data = ioResource.data
+    val schema = data.schema.json
+    val cols = data.columns.toList
+    val id = ioResource.configuration.path.split("/").filter(_.nonEmpty).last
+    val ioResourceConfig = ioResource.configuration.copy(
+      path = getContentPath(ioResource.configuration.path, ioResource.configuration.format)
+    )
+    Metadata(id, ioResourceConfig, schema, cols)
+  }
+
+  def create(ioResource: IOResource): IOResource = {
+    import context.sparkSession.implicits._
+    val metadata =
+      List(prepareMetadata(ioResource)).toDF
+        .withColumn("timeStamp", current_timestamp())
+        .coalesce(numPartitions = 1)
+
+    val metadataIOResource = IOResource(metadata, metadataSettings.output)
+
+    metadataIOResource
+  }
+
+  def write(metadata: IOResource): Unit = {
+    val data = metadata.data
+    val conf = metadata.configuration
+    logger.info(s"Save metadata: $conf")
+    data.write.format(conf.format).mode(metadataSettings.writeMode).save(conf.path)
+  }
+}

--- a/src/test/scala/io/opentargets/etl/backend/spark/MetadataHelperSpec.scala
+++ b/src/test/scala/io/opentargets/etl/backend/spark/MetadataHelperSpec.scala
@@ -1,0 +1,34 @@
+package io.opentargets.etl.backend.spark
+
+import org.scalatest.PrivateMethodTester
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
+
+class MetadataHelperSpec
+    extends AnyFlatSpec
+    with Matchers
+    with TableDrivenPropertyChecks
+    with PrivateMethodTester {
+  "Content root" should "be extracted from filepath" in {
+    val func = PrivateMethod[String]('getContentPath)
+    val tests = Table(
+      ("input", "format", "expected"),
+      ("gs://open-targets-pre-data-releases/22.11/output/etl/parquet/reactome",
+       "parquet",
+       "/reactome"
+      ),
+      ("gs://open-targets-pre-data-releases/22.11/output/etl/parquet/fda/adverseTargetReactions",
+       "parquet",
+       "/fda/adverseTargetReactions"
+      ),
+      ("gs://open-targets-pre-data-releases/22.11/output/etl/json/fda/adverseTargetReactions",
+       "json",
+       "/fda/adverseTargetReactions"
+      )
+    )
+    forAll(tests) { (in: String, fmt: String, exp: String) =>
+      MetadataHelper invokePrivate func(in, fmt) should be(exp)
+    }
+  }
+}


### PR DESCRIPTION
Updates metadata generation so that all outputs are provided with
metadata.

Metadata is now saved in the directory
`common.output-base-path`/metadata . Metadata for each dataset is
appended to this directory, so if we run the pipeline multiple times in
the same place without cleaning up after ourselves we potentially will
have multiple metadata files for the same input.

Resolves opentargets/platform#2780
