### PR TITLE
2211 release fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,9 @@ lazy val root = (project in file("."))
     testFrameworks += new TestFramework("minitest.runner.Framework"),
     mainClass in (Compile, run) := Some("io.opentargets.etl.Main"),
     mainClass in (Compile, packageBin) := Some("io.opentargets.etl.Main"),
+    assemblyShadeRules in assembly := Seq(
+      ShadeRule.rename("shapeless.**" -> "new_shapeless.@1").inAll
+    ),
     assemblyMergeStrategy in assembly := {
       case PathList("META-INF", "services", "org.apache.hadoop.fs.FileSystem") =>
         MergeStrategy.filterDistinctLines

--- a/configuration/2022/22_11_platform.conf
+++ b/configuration/2022/22_11_platform.conf
@@ -1,10 +1,20 @@
 // --- UPDATE THIS --- //
 spark-settings.write-mode = "ignore"
+
 data_version = "22.11"
 chembl_version = "31"
 ensembl_version = "108"
-efo_version = "v3.47.0"
 evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
 # update defaults for next release
 etl-dag.resolve = false
 // --- END - UPDATE THIS --- //
+//target.input.chemical-probes.path = "gs://open-targets-pre-data-releases/22.11/input/target-inputs/chemicalprobes/chemicalprobes.json.gz"
+//literature.processing.abstracts.path = "gs://otar025-epmc/Abstracts/**/*.jsonl"
+//literature.processing.full-texts.path = "gs://otar025-epmc/Full-text/**/*.jsonl"
+
+
+epmc.input.cooccurences.format = "parquet"
+epmc.input.cooccurences.path = "gs://open-targets-pre-data-releases/22.11/output/literature-etl/parquet/cooccurrences"
+
+// include this to short-circuit calculation of literature step
+literature.processing.outputs.literatureIndex.path = ${common.output}"/literature-etl/parquet/"

--- a/configuration/2022/22_11_platform.conf
+++ b/configuration/2022/22_11_platform.conf
@@ -1,0 +1,10 @@
+// --- UPDATE THIS --- //
+spark-settings.write-mode = "ignore"
+data_version = "22.11"
+chembl_version = "31"
+ensembl_version = "108"
+efo_version = "v3.47.0"
+evidences.data-sources-exclude = ["ot_crispr", "encore", "ot_crispr_validation"]
+# update defaults for next release
+etl-dag.resolve = false
+// --- END - UPDATE THIS --- //

--- a/configuration/2022/22_11_ppp.conf
+++ b/configuration/2022/22_11_ppp.conf
@@ -1,0 +1,27 @@
+// --- UPDATE THIS --- //
+spark-settings.write-mode = "ignore"
+data_version = "partners/22.11"
+chembl_version = "31"
+ensembl_version = "108"
+# update defaults for next release
+etl-dag.resolve = false
+
+// --- END - UPDATE THIS --- //
+
+
+otarproject {
+  otar-meta {
+    options = [
+      {k: "sep", v: ","},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+  otar-project-to-efo {
+    options = [
+      {k: "sep", v: ","},
+      {k: "header", v: "true"}
+      {k: "inferSchema", v: "true"}
+    ]
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   lazy val workflowDependencies: Seq[ModuleID] = Seq(
     configDeps,
     cats,
-    gcp,
+    gcpWorkflow,
     testingDeps,
     loggingDeps,
     cli
@@ -18,8 +18,8 @@ object Dependencies {
     graphDeps,
     sparkDeps,
     testingDeps,
-    gcp,
-    Seq(typeSafeConfig),
+    gcpEtl,
+    typeSafeConfig,
     johnS
   ).flatten
 
@@ -68,9 +68,13 @@ object Dependencies {
 
   lazy val typeSafeConfig = Seq("com.typesafe" % "config" % "1.4.1")
 
-  lazy val gcp = Seq(
+  lazy val gcpEtl = Seq(
+    "com.google.cloud" % "google-cloud-dataproc" % "4.2.0" % "provided",
+    "com.google.cloud" % "google-cloud-storage" % "2.4.2"
+  )
+  lazy val gcpWorkflow = Seq(
     "com.google.cloud" % "google-cloud-dataproc" % "4.2.0",
-    "com.google.cloud" % "google-cloud-storage" % "2.14.0",
+    "com.google.cloud" % "google-cloud-storage" % "2.4.2",
     // https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/26.1.4/index.html
     "io.grpc" % "grpc-netty-shaded" % "1.50.2", // needed for workflow to communicate with GCP
     "io.grpc" % "grpc-netty" % "1.50.2", // needed for workflow to communicate with GCP

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -280,7 +280,7 @@ target {
     chembl = ${drug.chembl-target}
     chemical-probes = {
       format = "json"
-      path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json"
+      path = ${common.input}"/target-inputs/chemicalprobes/chemicalprobes.json.gz"
     }
     ensembl {
       format = "json"
@@ -1341,11 +1341,11 @@ literature {
     }
     abstracts {
       format = "json"
-      path = "gs://otar025-epmc/Abstracts/"
+      path = "gs://otar025-epmc/Abstracts/**/*.jsonl"
     }
     full-texts {
       format = "json"
-      path = "gs://otar025-epmc/Full-text/"
+      path = "gs://otar025-epmc/Full-text/**/*.jsonl"
     }
     outputs = {
       raw-evidence {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1327,16 +1327,16 @@ literature {
       ]
     }
     diseases {
-      format = "parquet"
+      format = ${common.output-format}
       path = ${common.output}"/diseases"
     }
 
     targets {
-      format = "parquet"
+      format = ${common.output-format}
       path = ${common.output}"/targets"
     }
     drugs {
-      format = "parquet"
+      format = ${common.output-format}
       path = ${common.output}"/molecule"
     }
     abstracts {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1350,19 +1350,19 @@ literature {
     outputs = {
       raw-evidence {
         format = ${common.output-format}
-        path = ${common.output}"/rawEvidence"
+        path = ${literature.output}"/rawEvidence"
       }
       cooccurrences {
         format = ${common.output-format}
-        path = ${common.output}"/cooccurrences"
+        path = ${literature.output}"/cooccurrences"
       }
       matches {
        format = ${common.output-format}
-       path = ${common.output}"/matches"
+       path = ${literature.output}"/matches"
       }
       literature-index {
         format = ${common.output-format}
-        path = ${common.output}"/literatureIndex"
+        path = ${literature.output}"/literatureIndex"
       }
     }
   }
@@ -1379,11 +1379,11 @@ literature {
     outputs = {
       model = {
         format = ${common.output-format}
-        path = ${common.output}"/W2VModel"
+        path = ${literature.output}"/W2VModel"
       }
       training-set = {
         format = ${common.output-format}
-        path = ${common.output}"/trainingSet"
+        path = ${literature.output}"/trainingSet"
       }
     }
   }
@@ -1392,7 +1392,7 @@ literature {
     input = ${literature.embedding.outputs.model.path}
     output {
       format = ${common.output-format}
-      path = ${common.output}"/vectors"
+      path = ${literature.output}"/vectors"
     }
   }
 
@@ -1405,7 +1405,7 @@ literature {
     }
     output = {
       format = ${common.output-format}
-      path = ${common.output}"/evidence"
+      path = ${literature.output}"/evidence"
     }
   }
 }

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -95,7 +95,7 @@ object ETL extends LazyLogging {
       "drug" -> ctx.configuration.drug.outputs.drug.path,
       "knownDrug" -> ctx.configuration.knownDrugs.output.path,
       "ebisearch" -> ctx.configuration.ebisearch.outputs.ebisearchEvidence.path,
-      "fda" -> ctx.configuration.openfda.outputs.fdaResults.path,
+      "fda" -> ctx.configuration.openfda.stepRootOutputPath,
       "literature" -> ctx.configuration.literature.processing.outputs.literatureIndex.path
     )
 

--- a/src/main/scala/io/opentargets/etl/backend/OtarProject.scala
+++ b/src/main/scala/io/opentargets/etl/backend/OtarProject.scala
@@ -32,7 +32,7 @@ object OtarProject extends LazyLogging {
             col("otar_code").as("otar_code"),
             col("project_status").as("status"),
             col("project_name").as("project_name"),
-            col("integrates_data_PPP").cast(BooleanType).as("integrates_in_PPP"),
+            col("integrates_in_PPP").cast(BooleanType).as("integrates_data_PPP"),
             concat(lit("http://home.opentargets.org/"), col("otar_code")).as("reference")
           )
         ).as("projects")

--- a/src/main/scala/io/opentargets/etl/backend/literature/Grounding.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/Grounding.scala
@@ -612,7 +612,7 @@ object Grounding extends Serializable with LazyLogging {
     logger.info("producing grounding dataset")
     val mappedLabels =
       mapEntities(sentences, luts, pipeline, pipelineColumns)
-        .persist(StorageLevel.DISK_ONLY)
+        .persist(StorageLevel.MEMORY_AND_DISK)
         .orderBy(col("type"), col("label"))
 
     logger.info("resolve entities with the produced grounded labels")

--- a/src/main/scala/io/opentargets/etl/backend/literature/Literature.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/Literature.scala
@@ -17,7 +17,7 @@ object Literature extends LazyLogging {
 
   }
 
-  def createETLSession()(implicit context: ETLSessionContext) = {
+  def createETLSession()(implicit context: ETLSessionContext): ETLSessionContext = {
     val config = context.configuration
 
     val configurations = config.sparkSettings.defaultSparkSessionConfig
@@ -32,12 +32,16 @@ object Literature extends LazyLogging {
     etlSessionContext
   }
 
-  def runSteps(etlSessionContext: ETLSessionContext) = {
+  def runSteps(etlSessionContext: ETLSessionContext): Unit = {
     implicit val context: ETLSessionContext = etlSessionContext
 
+    logger.info("Run processing step")
     Processing()
+    logger.info("Run literature embedding")
     Embedding()
+    logger.info("Run literature vectors")
     Vectors()
+    logger.info("Run literature evidence")
     Evidence()
 
   }

--- a/src/main/scala/io/opentargets/etl/backend/literature/PreProcessing.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/PreProcessing.scala
@@ -17,7 +17,7 @@ object PreProcessing {
   def addGroupingColumns(epmc: DataFrame): DataFrame =
     epmc
       .select(col("*"), input_file_name)
-      .select(col("*"), regexp_extract(input_file_name, "full-text|abstracts", 0) as "kind")
+      .select(col("*"), regexp_extract(input_file_name, "Full-text|Abstracts", 0) as "kind")
       .withColumn("int_timestamp", unix_timestamp(col("timestamp")))
 
   def mergeInformationBackToUniques(uniqueDfRows: DataFrame, fullDF: DataFrame): DataFrame =

--- a/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
@@ -189,7 +189,7 @@ object Processing extends Serializable with LazyLogging {
     logger.info("Processing raw evidences and persist matches and cooccurrences")
 
     ("matches" :: "cooccurrences" :: Nil) foreach { l =>
-      grounding(l).persist(StorageLevel.DISK_ONLY)
+      grounding(l).persist(StorageLevel.MEMORY_AND_DISK)
     }
 
     val failedMatches = grounding("matchesFailed")
@@ -218,6 +218,7 @@ object Processing extends Serializable with LazyLogging {
       "matches" -> IOResource(matches, outputs.matches),
       "literatureIndex" -> IOResource(literatureIndexAlt, outputs.literatureIndex)
     )
+    logger.info(s"Write literatures outputs: ${dataframesToSave.keySet}")
 
     writeTo(dataframesToSave)
     dataframesToSave

--- a/src/test/scala/io/opentargets/etl/backend/OtarProjectTest.scala
+++ b/src/test/scala/io/opentargets/etl/backend/OtarProjectTest.scala
@@ -18,11 +18,11 @@ class OtarProjectTest extends EtlSparkUnitTest {
   ).toDF("id", "ancestors")
 
   lazy val inputOtarMeta: DataFrame = Seq(
-    ("OTAR_x01", "Project Alfa", "Active"),
-    ("OTAR_x02", "Project Beta", "Closed"),
-    ("OTAR_x04", "Project Gamma", "Active"),
-    ("OTAR_x07", "Project Delta", "Closed")
-  ).toDF("otar_code", "project_name", "project_status")
+    ("OTAR_x01", "Project Alfa", "Active", "true"),
+    ("OTAR_x02", "Project Beta", "Closed", "true"),
+    ("OTAR_x04", "Project Gamma", "Active", "true"),
+    ("OTAR_x07", "Project Delta", "Closed", "true")
+  ).toDF("otar_code", "project_name", "project_status", "integrates_in_ppp")
 
   lazy val inputOtarLookup: DataFrame = Seq(
     ("OTAR_x01", "EFO_0000729"),

--- a/workflow/src/main/resources/reference.conf
+++ b/workflow/src/main/resources/reference.conf
@@ -13,14 +13,15 @@ workflow-resources {
     path = ${gcp-settings.bucket}"/conf/"
     file = "2211.conf"
   }
+  java-settings = ["-XX:MaxPermSize=512m", "-XX:+UseCompressedOops"]
 }
 cluster {
   name = "open-targets-etl-cluster"
   zone = ${gcp-settings.region}"-d"
   image = "2.0-debian10"
   boot-disk-size = 2000 // size in GB
-  disk-type = "pd-ssd"
-  machine-type = "n1-highmem-96"
+  disk-type = "pd-standard"
+  machine-type = "n1-highmem-64"
   worker-count = 4
 }
 workflows = [

--- a/workflow/src/main/resources/reference.conf
+++ b/workflow/src/main/resources/reference.conf
@@ -19,6 +19,7 @@ cluster {
   zone = ${gcp-settings.region}"-d"
   image = "2.0-debian10"
   boot-disk-size = 2000 // size in GB
+  disk-type = "pd-ssd"
   machine-type = "n1-highmem-96"
   worker-count = 4
 }

--- a/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
@@ -13,7 +13,7 @@ case class ExistingOutputs(path: String, copyTo: String, sharedOutputs: List[Str
     file <- sharedOutputs
   } yield (path |+| file, copyTo |+| file)
 }
-case class WorkflowResources(jar: WfResource, config: WfResource)
+case class WorkflowResources(jar: WfResource, config: WfResource, javaSettings: List[String])
 case class WfResource(path: String, file: String) {
   require(path.endsWith("/"), "Path must end in \"/\"")
   val resource: String = path + file

--- a/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
@@ -15,7 +15,7 @@ case class ExistingOutputs(path: String, copyTo: String, sharedOutputs: List[Str
 }
 case class WorkflowResources(jar: WfResource, config: WfResource)
 case class WfResource(path: String, file: String) {
-  require(path.endsWith("/"))
+  require(path.endsWith("/"), "Path must end in \"/\"")
   val resource: String = path + file
 }
 

--- a/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/model/Configuration.scala
@@ -36,6 +36,7 @@ case class ClusterSettings(name: String,
                            zone: String,
                            image: String,
                            bootDiskSize: Int,
+                           diskType: String,
                            machineType: String,
                            workerCount: Int
 )

--- a/workflow/src/main/scala/io/opentargets/workflow/service/DataprocCluster.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/service/DataprocCluster.scala
@@ -25,7 +25,9 @@ object DataprocCluster {
     Reader(cs => GceClusterConfig.newBuilder.setZoneUri(cs.zone).build)
 
   private def createDiskConfig: ClusterR[DiskConfig] =
-    Reader(cs => DiskConfig.newBuilder.setBootDiskSizeGb(cs.bootDiskSize).build)
+    Reader(cs =>
+      DiskConfig.newBuilder.setBootDiskSizeGb(cs.bootDiskSize).setBootDiskType(cs.diskType).build
+    )
 
   private def createInstanceGroupConfig(disk: DiskConfig): ClusterR[InstanceGroupConfig] = Reader {
     cs =>

--- a/workflow/src/main/scala/io/opentargets/workflow/service/DataprocCluster.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/service/DataprocCluster.scala
@@ -42,6 +42,11 @@ object DataprocCluster {
     igc.map(igcb => igcb.setNumInstances(conf.workerCount).build).run(conf)
   }
 
+  /** Enabling endpoint-config allows us to access the Spark UI from without Dataproc without having
+    * to set up ssh tunnels.
+    */
+  private def endpointConfig =
+    EndpointConfig.newBuilder.setEnableHttpPortAccess(true).build
   private def createClusterConfig: ClusterR[ClusterConfig] =
     for {
       gceConf <- createGceClusterConfig
@@ -54,6 +59,7 @@ object DataprocCluster {
       .setSoftwareConfig(softwareConf)
       .setMasterConfig(masterConf)
       .setWorkerConfig(workerConf)
+      .setEndpointConfig(endpointConfig)
       .build
 
   private def getClusterName: ClusterR[String] = Reader(sc => sc.name)

--- a/workflow/src/main/scala/io/opentargets/workflow/service/DataprocJobs.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/service/DataprocJobs.scala
@@ -9,18 +9,22 @@ import scala.collection.JavaConverters._
 
 object DataprocJobs {
 
+  private def spaceSeparatedList[A](ls: List[A]): String = ls.mkString("", " ", "")
+
   /** @return
     *   a Spark job template which needs to be parameterised with a job name. The job name is the
     *   argument passed to the job.
     */
   private def createSparkJobFn: Reader[WorkflowResources, String => SparkJob] = Reader {
     conf => (jobArgument: String) =>
+      val javaOptions =
+        s"-Dconfig.file=${conf.config.file} ${spaceSeparatedList(conf.javaSettings)}"
       SparkJob.newBuilder
         .setMainJarFileUri(conf.jar.resource)
         .addArgs(jobArgument)
         .addFileUris(conf.config.resource)
-        .putProperties("spark.executor.extraJavaOptions", s"-Dconfig.file=${conf.config.file}")
-        .putProperties("spark.driver.extraJavaOptions", s"-Dconfig.file=${conf.config.file}")
+        .putProperties("spark.executor.extraJavaOptions", javaOptions)
+        .putProperties("spark.driver.extraJavaOptions", javaOptions)
         .build
   }
 

--- a/workflow/src/main/scala/io/opentargets/workflow/service/DataprocJobs.scala
+++ b/workflow/src/main/scala/io/opentargets/workflow/service/DataprocJobs.scala
@@ -29,7 +29,7 @@ object DataprocJobs {
 
   def createOrderedJob(job: Job): Reader[WorkflowResources, OrderedJob] = {
     val orderedJob = for {
-      sparkJob <- createJob(job.getJobId)
+      sparkJob <- createJob(job.arg)
     } yield OrderedJob.newBuilder
       .setStepId(job.getJobId)
       .setSparkJob(sparkJob)

--- a/workflow/src/test/scala/service/DataprocClusterSpec.scala
+++ b/workflow/src/test/scala/service/DataprocClusterSpec.scala
@@ -1,0 +1,41 @@
+package service
+
+import cats.effect.testing.scalatest.AsyncIOSpec
+import io.opentargets.workflow.model.{ClusterSettings, Configuration, Job}
+import io.opentargets.workflow.service.{DataprocCluster, DataprocJobs}
+import org.scalatest.AppendedClues
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DataprocClusterSpec extends AsyncFreeSpec with Matchers with AsyncIOSpec with AppendedClues {
+  "An cluster should" - {
+    val clusterSettings = ClusterSettings("cluster",
+                                          "europe-west-1",
+                                          "2.0-debian10",
+                                          2000,
+                                          "pd-ssd",
+                                          "n1-highmem-64",
+                                          4
+    )
+    "have 4 worker nodes" in {
+      // given
+      // when
+      val cluster = DataprocCluster.createWorkflowTemplatePlacement.run(clusterSettings)
+      val clusterConf = cluster.getManagedCluster.getConfig
+      // then
+      cluster.getManagedCluster.getConfig.hasMasterConfig shouldBe true withClue ("Cluster should have configured master config.")
+      cluster.getManagedCluster.getConfig.hasWorkerConfig shouldBe true withClue ("Cluster should have configured worker config.")
+    }
+    "have 0 worker nodes" in {
+      // given
+      val conf = clusterSettings.copy(workerCount = 0)
+      // when
+      val cluster = DataprocCluster.createWorkflowTemplatePlacement.run(conf)
+      val clusterConf = cluster.getManagedCluster.getConfig
+      // then
+      clusterConf.hasMasterConfig shouldBe true withClue ("Cluster should have configured master config.")
+      clusterConf.hasWorkerConfig shouldBe true withClue ("Cluster should have configured worker config.")
+      clusterConf.getWorkerConfig.getNumInstances shouldBe 0 withClue ("Cluster should have 0 workers.")
+    }
+  }
+}


### PR DESCRIPTION
Lots of small changes that came about because of the release, as well as the
usual addition of configuration files.

Changes:
- Some refactoring in Literature to make the names easier to understand
- Update the workflow to accept zero workers
- Update workflow to parameterise disk configuration
- Update FDA path in Main so that it short-circuits on pre-existing outputs
- Update OTAR to use the new data format. 
- Add configuration files (platform and PPP)
