### PR TITLE
Bug fix literature index, 'pmid' as String

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
@@ -79,7 +79,7 @@ object Processing extends Serializable with LazyLogging {
     )
 
     val matchesDF2 = matchesDF
-      .withColumn("pmid", $"pmid".cast(LongType))
+      //.withColumn("pmid", $"pmid".cast(LongType))
       .withColumnRenamed("type", "keywordType")
 
     val sentencesDF = matchesDF2

--- a/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
+++ b/src/main/scala/io/opentargets/etl/backend/literature/Processing.scala
@@ -79,7 +79,6 @@ object Processing extends Serializable with LazyLogging {
     )
 
     val matchesDF2 = matchesDF
-      //.withColumn("pmid", $"pmid".cast(LongType))
       .withColumnRenamed("type", "keywordType")
 
     val sentencesDF = matchesDF2


### PR DESCRIPTION
This PR changes _pmid_ type for ETL outputs from _Long_ to _String_