### PR TITLE
Adding recipe to ingest crispr_screen evidence

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -680,6 +680,15 @@ evidences {
       """
     },
     {
+      id: "crispr_screen",
+      unique-fields: [
+        "studyId",
+        "targetFromSourceId",
+        "diseaseFromSourceMappedId"
+      ],
+      score-expr: "pvalue_linear_score(resourceScore, 0.5, 0.005, 0.0, 1.0)"
+    },
+    {
       id: "europepmc",
       unique-fields: [
         "literature"


### PR DESCRIPTION
For the 23.06 Platform release a new evidence source is introduced: `crispr_screen`. The PR adds the logic to generate score.