### PR TITLE
Filter out incomplete data for a drug mechanism of action

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
@@ -55,13 +55,11 @@ object MechanismOfAction extends LazyLogging {
       .filter(
         """
           |mechanismOfAction is not null
-          |or references is not null
-          |or targetName is not null
-          |or targets is not null
-          |""".stripMargin
+          |and targets is not null and size(targets) > 0
+          |and chemblIds is not null and size(chemblIds) > 0
+        """.stripMargin
       )
       .drop("id")
-      .filter("chemblIds is not null")
       .distinct
       .transform(consolidateDuplicateReferences)
 


### PR DESCRIPTION
The Mechanism of Action table has irrelevant information that the data team will try to remodel in the future with ChEMBL. For the time being, this PR includes changes to the way the ETL processes the MoA data that were raised by [#3005](https://github.com/opentargets/issues/issues/3005):
- Switch the filtering condition from"OR"s to "AND"s, so that if any of the clauses is not met, that row is filtered out. After inspecting the data, the conditions are:
    - Rows with null in `mechanismOfAction` are filtered out;
    - Rows where `targets` is null or an empty array are discarded;
    - Rows where `chemblIds` is null or an empty array are discarded;

Having a healthy MoA table will close [#3005](https://github.com/opentargets/issues/issues/3005)