### PR TITLE
fix(MechanismOfAction): do not exclude moas with an empty list of targets

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/MechanismOfAction.scala
@@ -55,7 +55,7 @@ object MechanismOfAction extends LazyLogging {
       .filter(
         """
           |mechanismOfAction is not null
-          |and targets is not null and size(targets) > 0
+          |and (targets is not null or targetName is not null)
           |and chemblIds is not null and size(chemblIds) > 0
         """.stripMargin
       )


### PR DESCRIPTION
`targets` is a list of all EnsemblIDs that drug is targeting to. It is not correct to drop the records where this list is empty, because in many cases these refer to drugs that target a non human protein. Therefore, we just want to check they either an ensembl ID or a target name is present. More context here https://github.com/opentargets/issues/issues/3005#issuecomment-1697290163

Please pay extra attention to the OR clause. All 3 clauses need to evaluate to true, however the second one, the one related to the target information, can be true if the target name is present or if the targets list is not null. I added extra parenthesis for this, but I'm not sure this is correct in Scala.