### PR TITLE
adding non-dependent pharmacogenomics dataset

### DIFF
--- a/documentation/etl_current.puml
+++ b/documentation/etl_current.puml
@@ -29,6 +29,7 @@ artifact openfda <<dependencies>>
 artifact ebiSearch <<dependencies>>
 artifact otar <<dependencies>>
 artifact targetengine <<dependencies>>
+artifact pharmacogenomics <<noDependency>>
 
 disease --> otar
 reactome --> target

--- a/documentation/etl_current_full.puml
+++ b/documentation/etl_current_full.puml
@@ -25,6 +25,8 @@ artifact reactome <<noDependency>>
 artifact search <<dependencies>>
 artifact target <<dependencies>>
 artifact targetValidation <<dependencies>>
+artifact pharmacogenomics <<noDependency>>
+
 
 'inputs
 ' association
@@ -83,6 +85,9 @@ interface targetEssentiality <<input>>
 interface tractability <<input>>
 interface uniprot <<input>>
 interface reactomePathways <<input>>
+
+' pharmacogenomics
+interface pharmacogenomicsData <<input>>
 
 'safety
 interface safetyToxicity <<input>>
@@ -153,7 +158,8 @@ interface searchDrugOutput <<output>>
   ' targetValidation
  interface mousePhenotypes <<input>>
  interface mousePhenotypesOutput <<output>>
-
+  ' pharmacogenomics
+interface pharmacogenomicsOutput <<output>>
 
 
 ' relations
@@ -306,5 +312,9 @@ tep --> target
 targetEssentiality --> target
 tractability --> target
 uniprot --> target
+
+' pharmacogenomics
+pharmacogenomicsData --> pharmacogenomics
+pharmacogenomics --> pharmacogenomicsOutput
 
 @enduml

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -38,6 +38,7 @@ etl-dag {
     {step: "disease", dependencies: []},
     {step: "reactome", dependencies: []},
     {step: "expression", dependencies: []},
+    {step: "pharmacogenomics", dependencies: []},
     {step: "go", dependencies: []},
     {step: "target", dependencies: ["reactome"]},
     {step: "interaction", dependencies: ["target"]},
@@ -164,6 +165,17 @@ reactome {
   output = {
     format = ${common.output-format}
     path = ${common.output}"/reactome"
+  }
+}
+
+pharmacogenomics {
+  inputs {
+    format = "json"
+    path = ${common.input}"/pharmacogenomics-inputs/pharmacogenomics.json.gz"
+  }
+  outputs {
+    format = ${common.output-format}
+    path = ${common.output}"/pharmacogenomics"
   }
 }
 

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -63,6 +63,9 @@ object ETL extends LazyLogging {
       case "otar" =>
         logger.info("Running Otar projects step")
         OtarProject()
+      case "pharmacogenomics" =>
+        logger.info("run step pharmacogenomics")
+        Pharmacogenomics()
       case "reactome" =>
         logger.info("run step reactome (rea)")
         Reactome()
@@ -91,6 +94,7 @@ object ETL extends LazyLogging {
   def stepsWithExistingOuputs(implicit ctx: ETLSessionContext): Set[String] = {
     lazy val outputPaths: Map[String, String] = Map(
       "disease" -> ctx.configuration.disease.outputs.diseases.path,
+      "pharmacogenomics" -> ctx.configuration.pharmacogenomics.outputs.path,
       "reactome" -> ctx.configuration.reactome.output.path,
       "expression" -> ctx.configuration.expression.output.path,
       "baselineExpression" -> ctx.configuration.baselineExpression.outputs.baseline.path,

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -218,6 +218,8 @@ object Configuration extends LazyLogging {
 
   case class SearchSection(inputs: SearchInputsSection, outputs: SearchOutputsSection)
 
+  case class PharmacogenomicsSection(inputs: IOResourceConfig, outputs: IOResourceConfig)
+
   case class ReactomeSectionInputs(pathways: IOResourceConfig, relations: IOResourceConfig)
 
   case class ReactomeSection(inputs: ReactomeSectionInputs, output: IOResourceConfig)
@@ -395,6 +397,7 @@ object Configuration extends LazyLogging {
       sparkSettings: SparkSettings,
       etlDag: EtlDagConfig,
       common: Common,
+      pharmacogenomics: PharmacogenomicsSection,
       reactome: ReactomeSection,
       associations: AssociationsSection,
       evidences: EvidencesSection,

--- a/src/main/scala/io/opentargets/etl/backend/Pharmacogenomics.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Pharmacogenomics.scala
@@ -1,0 +1,29 @@
+package io.opentargets.etl.backend
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import io.opentargets.etl.backend.spark.{IOResource, IoHelpers}
+import org.apache.spark.sql.SparkSession
+
+object Pharmacogenomics extends LazyLogging {
+  def apply()(implicit context: ETLSessionContext): IOResources = {
+    implicit val ss: SparkSession = context.sparkSession
+
+    logger.info("Executing Pharmacogenomics step.")
+
+    logger.debug("Reading Pharmacogenomics input")
+    val mappedInputs = Map("pgx" -> context.configuration.pharmacogenomics.inputs)
+
+    logger.debug("Processing Pharmacogenomics data")
+    val inputDataFrames = IoHelpers.readFrom(mappedInputs)
+    val pgxDF = inputDataFrames("pgx").data
+
+    logger.debug("Writing Pharmacogenomics outputs")
+    val dataframesToSave: IOResources = Map(
+      "pgx" -> IOResource(pgxDF, context.configuration.pharmacogenomics.outputs)
+    )
+
+    IoHelpers.writeTo(dataframesToSave)
+  }
+
+}

--- a/workflow/src/main/resources/reference.conf
+++ b/workflow/src/main/resources/reference.conf
@@ -25,8 +25,8 @@ cluster {
   worker-count = 4
 }
 workflows = [
-  {name = "public", steps = ["disease", "epmc", "reactome", "baselineExpression", "expression", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
-  {name = "private", steps = ["otar","disease", "epmc", "reactome", "baselineExpression", "expression", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
+  {name = "public", steps = ["disease", "epmc", "reactome", "pharmacogenomics", "baselineExpression", "expression", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
+  {name = "private", steps = ["otar","disease", "epmc", "reactome", "pharmacogenomics", "baselineExpression", "expression", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
 ]
 
 existing-outputs {
@@ -47,6 +47,7 @@ existing-outputs {
     "interactionEvidence",
     "mousePhenotypes",
     "reactome",
+    "pharmacogenomics",
     "targets",
   ]
 }
@@ -70,6 +71,9 @@ jobs = [
   },
   {
     arg = "expression"
+  },
+  {
+    arg = "pharmacogenomics"
   },
   {
     arg = "go",


### PR DESCRIPTION
ETL part of opentargets/issues#3127. 
- update puml
- added non-dependent step to config
- added pharmacogenomics backend. Currently it only reads the input and writes it without any transformations.