### PR TITLE
Fix first run of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ set_profile: ## Set an active configuration profile, e.g. "make set_profile prof
 	@echo "[ETL] Setting active profile '${profile}'"
 	@ln -sf profiles/config.${profile} ${ETL_ACTIVE_PROFILE}
 
+${ETL_ACTIVE_PROFILE}: ## Set the default configuration profile if there is no profile set.
+	@ln -sf profiles/config.default ${ETL_ACTIVE_PROFILE}
+
 .PHONY: etl_config
 etl_config: ## Instantiate the ETL config.
 	@echo "[ETL] Instantiating ETL config"


### PR DESCRIPTION
When running any Make targets for the first time in a clean clone of the repo, they fail:

```
Makefile:5: .env: No such file or directory
make: *** No rule to make target `.env'.  Stop.
```

In line 5, the Makefile is trying to include `.env`, and that file will not exist unless created before. The file should be created by another target: `make set_profile`, but you cannot run it because it will fail on the `include` statement.

According to Make docs:

> If an included makefile cannot be found in any of these directories it is not an immediately fatal error; processing of the makefile containing the include continues. Once it has finished reading makefiles, make will try to remake any that are out of date or don’t exist. See [How Makefiles Are Remade](https://www.gnu.org/software/make/manual/html_node/Remaking-Makefiles.html). Only after it has failed to find a rule to remake the makefile, or it found a rule but the recipe failed, will make diagnose the missing makefile as a fatal error.

As there is no rule to create `.env` directly, the error is fatal. This PR adds a target to make sure that file exists. It links the default profile into that file. That target will be automatically called by Make if `.env` does not exist.

Another option could be to ignore the non-existant file:

> If you want make to simply ignore a makefile which does not exist or cannot be remade, with no error message, use the -include directive instead of include.

But that would probably cause problems on other targets.