### PR TITLE
fix(evidence score): fixing score expression for validation lab

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1016,7 +1016,7 @@ evidences {
       unique-fields: [
         "targetFromSourceId", "diseaseFromSourceMappedId", "resourceScore"
       ],
-      score-expr: "element_at(map('significant', 1.0, 'not significant', 0.0), confidence)"
+      score-expr: "resourceScore"
     },
     {
       id: "orphanet",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1014,7 +1014,7 @@ evidences {
     {
       id: "ot_crispr_validation",
       unique-fields: [
-        "targetFromSourceId", "diseaseFromSourceMappedId", "resourceScore"
+        "targetFromSourceId", "diseaseFromSourceMappedId", "resourceScore", "diseaseCellLines", "primaryProjectId"
       ],
       score-expr: "resourceScore"
     },


### PR DESCRIPTION
The existing scoring expression was obsolete and incompatible with the new validation lab schema. The new numeric value is coming directly from VL. This value represents the fraction of assays that were positive for the given cell line.

This is coming from VL:

```
"OTVL_Assessment_Score" entries for Breast are scaled to range from 0 to 1. Since the Colo data contains only a single
 assay, the entries for "OTVL_Assessment_Score" in the colo report file are scaled to run from 0 to 1/3
```

In the parser:

```python
# Extract assessment score:
f.col("OTVL_Assessment_Score")
.cast(t.FloatType())
.alias("resourceScore"),
```