### PR TITLE
3361 remove classic aotf aggs data

### DIFF
--- a/documentation/etl_current_full.puml
+++ b/documentation/etl_current_full.puml
@@ -96,7 +96,6 @@ interface associationByDatatypeIndirect <<output>>
 interface associationByOverallIndirect <<output>>
   ' aotf
 interface AotfClickhouseOutput <<output>>
-interface AotfElasticsearchOutput <<output>>
   ' disease
 interface diseaseOutput <<output>>
 interface diseaseHpoOutput <<output>>
@@ -162,8 +161,6 @@ evidenceOutput --> associationOTF
 diseaseOutput --> associationOTF
 targetOutput --> associationOTF
 associationOTF --> AotfClickhouseOutput
-associationOTF --> AotfElasticsearchOutput
-
   ' disease
 efoOntology --> disease
 hpoOntology --> disease

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -74,7 +74,7 @@ common {
 
   input = "gs://open-targets-pre-data-releases/"${data_version}"/input"
   error = ${common.output}"/errors/"
-  additional-outputs = ["json"]
+  additional-outputs = []
 
 }
 
@@ -1203,12 +1203,7 @@ aotf {
       format = ${common.output-format}
       path = ${common.output}"/AOTFClickhouse"
     }
-    elasticsearch = {
-      format = "json"
-      path = ${common.output}"/AOTFElasticsearch"
-    }
   }
-
   inputs = {
     evidences = ${evidences.outputs.succeeded}
     diseases = ${disease.outputs.diseases}

--- a/src/main/scala/io/opentargets/etl/backend/AssociationOTF.scala
+++ b/src/main/scala/io/opentargets/etl/backend/AssociationOTF.scala
@@ -149,14 +149,6 @@ object AssociationOTF extends LazyLogging {
       .join(diseasesFacetTAs, Seq("disease_id"), "left_outer")
       .drop("therapeuticAreas")
 
-    val columnsToDrop = Seq(
-      "mutatedSamples",
-      "diseaseModelAssociatedModelPhenotypes",
-      "diseaseModelAssociatedHumanPhenotypes",
-      "textMiningSentences",
-      "clinicalUrls"
-    )
-
     val evidenceColumns = Seq(
       "id as row_id",
       "diseaseId as disease_id",
@@ -177,12 +169,6 @@ object AssociationOTF extends LazyLogging {
       "target_data"
     )
 
-    val elasticsearchDF = dfs("evidences").data
-      .drop(columnsToDrop: _*)
-      .selectExpr(evidenceColumns: _*)
-      .join(finalDiseases, Seq("disease_id"), "left_outer")
-      .join(finalTargets, Seq("target_id"), "left_outer")
-
     val clickhouseDF = dfs("evidences").data
       .selectExpr(evidenceColumns: _*)
       .join(finalDiseases, Seq("disease_id"), "left_outer")
@@ -190,7 +176,6 @@ object AssociationOTF extends LazyLogging {
       .selectExpr(evidenceColumnsCleaned: _*)
 
     Map(
-      "aotfsElasticsearch" -> IOResource(elasticsearchDF, conf.aotf.outputs.elasticsearch),
       "aotfsClickhouse" -> IOResource(clickhouseDF, conf.aotf.outputs.clickhouse)
     )
   }

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -103,7 +103,7 @@ object Configuration extends LazyLogging {
       targets: IOResourceConfig
   )
 
-  case class AOTFOutputsSection(clickhouse: IOResourceConfig, elasticsearch: IOResourceConfig)
+  case class AOTFOutputsSection(clickhouse: IOResourceConfig)
 
   case class AOTFSection(
       outputs: AOTFOutputsSection,


### PR DESCRIPTION
- part of opentargets/issues#3361 to remove the classic aotf aggregation facets data i.e. the aotf evidence index.