### PR TITLE
Revert "fix(molecule): harmonise null drug types"

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
+++ b/src/main/scala/io/opentargets/etl/backend/drug/Molecule.scala
@@ -70,7 +70,7 @@ object Molecule extends LazyLogging {
         col("molecule_chembl_id").as("id"),
         col("molecule_structures.canonical_smiles").as("canonicalSmiles"),
         col("molecule_structures.standard_inchi_key").as("inchiKey"),
-        when(col("molecule_type").isNull || col("molecule_type") === "Unknown", lit("unknown")).otherwise(col("molecule_type")).as("drugType"),
+        coalesce(col("molecule_type"), lit("unknown")).as("drugType"),
         col("chebi_par_id"),
         col("black_box_warning").as("blackBoxWarning"),
         col("pref_name").as("name"),


### PR DESCRIPTION
Reverts opentargets/platform-etl-backend#346 as this issue was resolved by https://github.com/opentargets/platform-etl-backend/pull/347 (which went to the release branch)