### PR TITLE
feat(uniprot_variants): add `variantId` as an unique field

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1080,7 +1080,7 @@ evidences {
       id: "uniprot_literature"
       datatype-id: "genetic_association"
       unique-fields: [
-        "diseaseFromSource",
+        "diseaseFromSource"
       ],
       score-expr: """
       element_at(
@@ -1099,7 +1099,7 @@ evidences {
       unique-fields: [
         "diseaseFromSource",
         "variantRsId",
-        "variantId",
+        "variantId"
       ],
       score-expr: """
       element_at(

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1098,7 +1098,8 @@ evidences {
       datatype-id: "genetic_association"
       unique-fields: [
         "diseaseFromSource",
-        "variantRsId"
+        "variantRsId",
+        "variantId",
       ],
       score-expr: """
       element_at(


### PR DESCRIPTION
This datasource reports variation with rsIDs.
We are postprocessing it to add the variantId. Because rsIDs are ambiguous, this addition causes an explosion in the data, meaning that there will be multiple evidence strings reporting the same disease and rsId.

To avoid them being marked as duplicates, we should add `variantId` as an unique field