### PR TITLE
3499 sequence ontology

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -54,7 +54,8 @@ etl-dag {
     {step: "ebisearch", dependencies: ["target", "disease", "evidence", "association"]},
     {step: "fda", dependencies: ["drug"]},
     {step: "otar", dependencies: ["disease"]},
-    {step: "targetengine", dependencies: ["target", "drug"]}
+    {step: "targetengine", dependencies: ["target", "drug"]},
+    {step: "so", dependencies: []}
   ]
 }
 
@@ -1590,5 +1591,26 @@ target-engine {
       path = ${common.output}"/targetPrioritisation"
       format = ${common.output-format}
     }
+  }
+}
+
+so {
+  inputs {
+    nodes {
+      format = "json"
+      path = ${common.input}"/sequenceOntology/nodes.jsonl"
+    }
+    properties {
+      format = "json"
+      path = ${common.input}"/sequenceOntology/properties.jsonl"
+    }
+    subclasses {
+      format = "json"
+      path = ${common.input}"/sequenceOntology/subclasses.jsonl"
+    }
+  }
+  output {
+    format = ${common.output-format}
+    path = ${common.output}"/so"
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1600,14 +1600,6 @@ so {
       format = "json"
       path = ${common.input}"/sequenceOntology/nodes.jsonl"
     }
-    properties {
-      format = "json"
-      path = ${common.input}"/sequenceOntology/properties.jsonl"
-    }
-    subclasses {
-      format = "json"
-      path = ${common.input}"/sequenceOntology/subclasses.jsonl"
-    }
   }
   output {
     format = ${common.output-format}

--- a/src/main/scala/io/opentargets/etl/Main.scala
+++ b/src/main/scala/io/opentargets/etl/Main.scala
@@ -14,6 +14,7 @@ import io.opentargets.etl.backend.literature.{Epmc, Literature}
 import io.opentargets.etl.backend.facetSearch.FacetSearch
 import io.opentargets.etl.backend.literature.{Epmc, Literature}
 import io.opentargets.etl.backend.pharmacogenomics.Pharmacogenomics
+import io.opentargets.etl.backend.so.SequenceOntology
 import io.opentargets.etl.backend.targetEngine.TargetEngine
 import io.opentargets.etl.common.GoogleStorageHelpers
 
@@ -86,6 +87,9 @@ object ETL extends LazyLogging {
       case "targetengine" =>
         logger.info("run step target engine")
         TargetEngine()
+      case "so" =>
+        logger.info("run step target engine")
+        SequenceOntology()
       case _ => throw new IllegalArgumentException(s"step $step is unknown.")
     }
     logger.info(s"finished to run step ($step)")
@@ -113,7 +117,8 @@ object ETL extends LazyLogging {
       "ebisearch" -> ctx.configuration.ebisearch.outputs.ebisearchEvidence.path,
       "fda" -> ctx.configuration.openfda.stepRootOutputPath,
       "literature" -> ctx.configuration.literature.processing.outputs.literatureIndex.path,
-      "targetengine" -> ctx.configuration.targetEngine.outputs.targetEngine.path
+      "targetengine" -> ctx.configuration.targetEngine.outputs.targetEngine.path,
+      "so" -> ctx.configuration.so.output.path
     )
 
     val storage: Storage = StorageOptions.getDefaultInstance.getService

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -431,6 +431,13 @@ object Configuration extends LazyLogging {
 
   case class EtlDagConfig(steps: List[EtlStep[String]], resolve: Boolean)
 
+  case class soInputs(nodes: IOResourceConfig,
+                      properties: IOResourceConfig,
+                      subclasses: IOResourceConfig
+  )
+
+  case class SequenceOntology(inputs: soInputs, output: IOResourceConfig)
+
   case class OTConfig(
       sparkUri: Option[String],
       sparkSettings: SparkSettings,
@@ -455,6 +462,7 @@ object Configuration extends LazyLogging {
       ebisearch: EBISearchSection,
       otarproject: OtarProjectSection,
       literature: LiteratureSection,
-      targetEngine: TargetEngineSection
+      targetEngine: TargetEngineSection,
+      so: SequenceOntology
   )
 }

--- a/src/main/scala/io/opentargets/etl/backend/Configuration.scala
+++ b/src/main/scala/io/opentargets/etl/backend/Configuration.scala
@@ -431,10 +431,7 @@ object Configuration extends LazyLogging {
 
   case class EtlDagConfig(steps: List[EtlStep[String]], resolve: Boolean)
 
-  case class soInputs(nodes: IOResourceConfig,
-                      properties: IOResourceConfig,
-                      subclasses: IOResourceConfig
-  )
+  case class soInputs(nodes: IOResourceConfig)
 
   case class SequenceOntology(inputs: soInputs, output: IOResourceConfig)
 

--- a/src/main/scala/io/opentargets/etl/backend/so/SequenceOntology.scala
+++ b/src/main/scala/io/opentargets/etl/backend/so/SequenceOntology.scala
@@ -1,0 +1,91 @@
+package io.opentargets.etl.backend.so
+
+import com.typesafe.scalalogging.LazyLogging
+import io.opentargets.etl.backend.ETLSessionContext
+import io.opentargets.etl.backend.spark.IoHelpers
+import io.opentargets.etl.backend.spark.IoHelpers.IOResources
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+
+object SequenceOntology extends LazyLogging {
+
+  // Define schema for the array of structs
+//  val keyValueSchema: ArrayType = ArrayType(StructType(List(
+//    StructField("pred", StringType, nullable = true),
+//    StructField("val", StringType, nullable = true)
+//  )))
+
+  def apply()(implicit context: ETLSessionContext): Unit = {
+    implicit val ss = context.sparkSession
+
+    val soConfig = context.configuration.so
+
+    val soInputs = Map(
+      "nodes" -> soConfig.inputs.nodes,
+      "properties" -> soConfig.inputs.properties,
+      "subclasses" -> soConfig.inputs.subclasses
+    )
+
+    val inputsDfs = IoHelpers.readFrom(soInputs)
+
+    val nodesDf = inputsDfs("nodes").data
+
+    // Extract the values from url format for the id fields
+    val idAtPrefix = element_at(split(col("id"), "/"), -2)
+    val idAtValue = element_at(split(col("id"), "/"), -1)
+    val id = element_at(split(idAtValue, "_"), 2)
+    val idPrefix = element_at(split(idAtValue, "_"), 1)
+
+    val owlPrefix = "owl:"
+
+    val flattenNodesDf = nodesDf.select(
+      concat(idAtPrefix, lit(":"), idAtValue).as("@id"),
+      concat(idPrefix, lit(":"), id).as("id"),
+      col("lbl").as("label"),
+      concat(lit(owlPrefix), col("type")).as("@type"),
+      col("meta.*")
+    )
+
+    val valCol = element_at(split(col("col.val"), "/"), -1).as("val")
+    val predCol = element_at(split(col("col.pred"), "/"), -1).as("pred")
+    val cleanPredCol = when(col("pred").contains("#"), element_at(split(col("pred"), "#"), -1))
+      .otherwise(col("pred"))
+    val propertiesLUT = flattenNodesDf
+      .select(col("id"), explode(col("basicPropertyValues")))
+      .select(col("id"), predCol, valCol)
+      .withColumn("pred", cleanPredCol)
+      .groupBy("id")
+      .pivot("pred")
+      .agg(first("val"))
+    val nodesWithPropertiesDF = flattenNodesDf
+      .join(propertiesLUT, Seq("id"))
+      .drop("basicPropertyValues")
+
+    val synonymsLUT = flattenNodesDf
+      .select(col("id"), explode(col("Synonyms")))
+      .select(col("id"), predCol, valCol)
+      .withColumn("pred", cleanPredCol)
+      .groupBy("id")
+      .pivot("pred")
+      .agg(collect_list("val"))
+    val nodesWithSynonymsDF = nodesWithPropertiesDF
+      .join(synonymsLUT, Seq("id"))
+      .drop("Synonyms")
+
+    val propertiesDF = inputsDfs("properties").data
+    val commentsColName = propertiesDF
+      .where(col("lbl") === "definition")
+      .select(element_at(split(col("id"), "/"), -1))
+      .first()
+      .getString(0)
+    val nodesWithDefinitionRenamedDf = nodesWithSynonymsDF
+      .select(col("*"), col("definition.val").as(commentsColName))
+      .drop("definition")
+
+    val nodesRenamedFiledsDf = nodesWithDefinitionRenamedDf.select(col("*"),col("deprecated").as(owlPrefix+"deprecated")).drop("deprecated")
+
+    logger.info("End of sequence ontology step")
+  }
+
+}

--- a/workflow/src/main/resources/reference.conf
+++ b/workflow/src/main/resources/reference.conf
@@ -32,8 +32,8 @@ labels {
   tool = "etl"
 }
 workflows = [
-  {name = "public", steps = ["disease", "reactome", "pharmacogenomics", "expression", "facetSearch", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
-  {name = "private", steps = ["otar","disease", "reactome", "pharmacogenomics", "expression", "facetSearch", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine"]}
+  {name = "public", steps = ["disease", "reactome", "pharmacogenomics", "expression", "facetSearch", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine", "so"]}
+  {name = "private", steps = ["otar","disease", "reactome", "pharmacogenomics", "expression", "facetSearch", "go-step", "target", "interaction", "targetValidation", "evidence", "association", "associationOTF", "search", "drug", "knownDrug", "ebiSearch", "fda", "literature", "targetEngine", "so"]}
 ]
 
 existing-outputs {
@@ -64,6 +64,9 @@ existing-outputs {
 jobs = [
   {
     arg = "disease"
+  },
+  {
+    arg = "so"
   },
   {
     arg = "reactome"


### PR DESCRIPTION
Add new SO step to the ETL to map the sequence ontology inputs and solve item [3499](https://github.com/opentargets/issues/issues/3499)
- **Add Sequence Ontology Add so Configuration Add basic props mapping Add synonyms mappings Add definition mapping**
- **add logging**
- **refactor to extract logic to methods**
- **leave only fields used by the API**
