### PR TITLE
feat: adding new evidence set to config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -926,6 +926,14 @@ evidences {
       score-expr: "resourceScore"
     },
     {
+      id: "gwas_credible_sets",
+      datatype-id: "genetic_association"
+      unique-fields: [
+        "studyLocusId",
+      ],
+      score-expr: "resourceScore"
+    },
+    {
       id: "ot_crispr",
       datatype-id: "ot_partner",
       unique-fields: [


### PR DESCRIPTION
Configuring the platform ETL to ingest the new genetics evidence. Setting up:

- Scoring (based on the value of `resourceScore`)
- Unique field (`studyLocusId` + target, disease)
