### PR TITLE
feat: add tss column to target index

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Target.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Target.scala
@@ -166,6 +166,7 @@ object Target extends LazyLogging {
       .transform(addTargetSafety(inputDataFrames, ensemblIdLookupDf))
       .transform(addReactome(reactome))
       .transform(removeDuplicatedSynonyms)
+      .transform(addTss)
 
     val targetEssentialityDF = targetsDF
       .transform(addGeneEssentiality(inputDataFrames("geneEssentiality").data, ensemblIdLookupDf))
@@ -173,6 +174,15 @@ object Target extends LazyLogging {
     Map(
       "target" -> targetsDF,
       "targetEssentiality" -> targetEssentialityDF
+    )
+  }
+
+  private def addTss(dataFrame: DataFrame): DataFrame = {
+    logger.info("Adding tss column to target dataframe")
+    dataFrame.withColumn(
+      "tss",
+      when(col("canonicalTranscript.strand") === 1, col("canonicalTranscript.start"))
+        .when(col("canonicalTranscript.strand") === -1, col("canonicalTranscript.end"))
     )
   }
 


### PR DESCRIPTION
Gentropy uses a `gene_index` which contains a subset of columns from the target index in the platform etl, plus an additional `tss` column.  As the gentropy pipelines will now use the target index directly, we should add the `tss` column to the target index.

This PR adds the `tss` column to the target index.