### PR TITLE
fix: change values of strand in the addTss function

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/target/Target.scala
+++ b/src/main/scala/io/opentargets/etl/backend/target/Target.scala
@@ -181,8 +181,8 @@ object Target extends LazyLogging {
     logger.info("Adding tss column to target dataframe")
     dataFrame.withColumn(
       "tss",
-      when(col("canonicalTranscript.strand") === 1, col("canonicalTranscript.start"))
-        .when(col("canonicalTranscript.strand") === -1, col("canonicalTranscript.end"))
+      when(col("canonicalTranscript.strand") === "+", col("canonicalTranscript.start"))
+        .when(col("canonicalTranscript.strand") === "-", col("canonicalTranscript.end"))
     )
   }
 


### PR DESCRIPTION
See PR #369 

Values of `canonicalTranscript.strand` should be "+" and "-", not 1 and -1