### PR TITLE
chore: removing references to ot_genetics from configuration and etl

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -623,7 +623,6 @@ evidences {
       "STABILISER"
     ]
     sources = [
-       "ot_genetics_portal",
        "gene_burden",
        "eva",
        "eva_somatic",
@@ -889,15 +888,6 @@ evidences {
         "cohortShortName"
       ],
       score-expr: "pvalue_linear_score(resourceScore, 0.1, 1e-10, 0.25, 1.0)"
-    },
-    {
-      id: "ot_genetics_portal",
-      datatype-id: "genetic_association"
-      unique-fields: [
-        "studyId",
-        "variantId"
-      ],
-      score-expr: "resourceScore"
     },
     {
       id: "gwas_credible_sets",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1305,7 +1305,7 @@ ebisearch {
   target-etl = ${target.outputs.target}
   evidence-etl {
     format = ${common.output-format}
-    path = ${evidences.outputs.succeeded.path}"/sourceId=ot_genetics_portal/"
+    path = ${evidences.outputs.succeeded.path}"/sourceId=gwas_credible_sets/"
   }
   association-etl = ${associations.outputs.direct-by-overall}
   outputs = {

--- a/src/main/scala/io/opentargets/etl/backend/evidence/DirectionOfEffect.scala
+++ b/src/main/scala/io/opentargets/etl/backend/evidence/DirectionOfEffect.scala
@@ -179,46 +179,6 @@ object DirectionOfEffect {
       .withColumn(
         "variantEffect",
         when(
-          col("datasourceId") === "ot_genetics_portal",
-          when(
-            col("variantFunctionalConsequenceId").isNotNull,
-            when(
-              col("variantFunctionalConsequenceFromQtlId").isNull,
-              when(
-                variantIsLoF,
-                lit("LoF")
-              )
-                .when(
-                  variantIsGoF,
-                  lit("GoF")
-                )
-                .otherwise(lit(null))
-            )
-              // variantFunctionalConsequenceFromQtlId
-              .when(
-                col("variantFunctionalConsequenceFromQtlId").isNotNull,
-                when(
-                  variantIsLoF,
-                  geneProductLevel(whenDecrease = lit("LoF"), whenIncrease = lit(null))
-                    .otherwise(lit("LoF"))
-                ).when(
-                  not(variantIsLoF), // when is not a LoF, still can be a GoF
-                  when(
-                    not(variantIsGoF), // if not GoF
-                    geneProductLevel(whenDecrease = lit("LoF"), whenIncrease = lit("GoF"))
-                      .otherwise(lit(null))
-                  ).when(
-                    variantIsGoF, // if is GoF
-                    geneProductLevel(whenDecrease = lit(null), whenIncrease = lit("GoF"))
-                  )
-                )
-              )
-          ).when(
-            col("variantFunctionalConsequenceId").isNull,
-            geneProductLevel(whenDecrease = lit("LoF"), whenIncrease = lit("GoF"))
-              .otherwise(lit(null))
-          )
-        ).when(
           col("datasourceId") === "gene_burden",
           when(col("targetId").isNotNull, lit("LoF")).otherwise(
             lit(null)
@@ -311,10 +271,6 @@ object DirectionOfEffect {
         "directionOnTrait",
         // ot genetics portal
         when(
-          col("datasourceId")
-            === "ot_genetics_portal", // the same for gene_burden
-          betaValidation
-        ).when(
           col("datasourceId") === "gene_burden",
           betaValidation
         )


### PR DESCRIPTION
## Context for this PR:

As the issue [#3715](https://github.com/opentargets/issues/issues/3715) explains, we are dropping `ot_genetics` evidence. This includes:

- [x] Removing references from configuration.
- [x] Removing ot_genetics specific logic to determine direction of effect on gene and disease.
- [x] Removing ot_genetics specific logic to build dataset for EBI Search.