### PR TITLE
feat: adding studyStartDate as source of evidenceDate

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/evidence/Evidence.scala
+++ b/src/main/scala/io/opentargets/etl/backend/evidence/Evidence.scala
@@ -263,8 +263,10 @@ object Evidence extends LazyLogging {
       .withColumn(
         "evidenceDate",
         coalesce(
+          // To pick evidence date the highest priority is the studyStartDate, then releaseDate the lowest is publicationDate
           col("publicationDate"),
-          col("releaseDate")
+          col("releaseDate"),
+          col("studyStartDate")
         )
       )
 


### PR DESCRIPTION
## Context

This update includes `studyStartDate` as source of `evidenceDate`. This change enables dating ChEMBL evidence. 

Number of evidence with available `studyStartDate`:

```
+------------+------+
|datasourceId| count|
+------------+------+
|      chembl|485114|
+------------+------+
```