### PR TITLE
fix(ebi search): reverting column name

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/SearchEBI.scala
+++ b/src/main/scala/io/opentargets/etl/backend/SearchEBI.scala
@@ -34,7 +34,7 @@ object SearchEBI extends LazyLogging {
         col("diseaseId"),
         col("approvedSymbol"),
         col("name"),
-        col("associationScore").alias("score")
+        col("score")
       )
     Map(
       "ebisearchAssociations" -> datasetAssociations,


### PR DESCRIPTION
Obviously the schema change in the association dataset does not apply when the search dataset is built from the evidence. 🤦🏻 