### PR TITLE
chore(interaction): changing column names to camel case

### DIFF
--- a/src/test/scala/io/opentargets/etl/backend/SearchEBITest.scala
+++ b/src/test/scala/io/opentargets/etl/backend/SearchEBITest.scala
@@ -29,7 +29,7 @@ object SearchEBITest {
       ("ENSG00000171862", "EFO_0000729", 0.4323)
     )
     val evidence =
-      sparkSession.createDataFrame(inputEvidence).toDF("targetId", "diseaseId", "score")
+      sparkSession.createDataFrame(inputEvidence).toDF("targetId", "diseaseId", "associationScore")
 
     val inputAssociations = Seq(
       ("ENSG00000171862", "EFO_0003767", 0.8737),


### PR DESCRIPTION
# Context

Camel casing datasets([#4271](https://github.com/opentargets/issues/issues/4271))

- [x] Interction

## Local run output
- Interaction dataset (row count matches)
```
root
 |-- sourceDatabase: string (nullable = true)
 |-- targetA: string (nullable = true)
 |-- intA: string (nullable = true)
 |-- intABiologicalRole: string (nullable = true)
 |-- targetB: string (nullable = true)
 |-- intB: string (nullable = true)
 |-- intBBiologicalRole: string (nullable = true)
 |-- speciesA: struct (nullable = true)
 |    |-- mnemonic: string (nullable = true)
 |    |-- scientificName: string (nullable = true)
 |    |-- taxonId: long (nullable = true)
 |-- speciesB: struct (nullable = true)
 |    |-- mnemonic: string (nullable = true)
 |    |-- scientificName: string (nullable = true)
 |    |-- taxonId: long (nullable = true)
 |-- count: long (nullable = true)
 |-- scoring: double (nullable = true)
```