### PR TITLE
fix: updated gene ontology column reference

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/searchFacet/TargetFacets.scala
+++ b/src/main/scala/io/opentargets/etl/backend/searchFacet/TargetFacets.scala
@@ -248,7 +248,6 @@ object TargetFacets extends LazyLogging {
       .flatMap(row => row.go.map(g => (row.ensemblId, g.id, g.aspect)))
       .toDF("ensemblGeneId", "id", "category")
       .join(goDF, Seq("id"), "left")
-      .withColumn("label", col("name"))
       .withColumn("datasourceId", col("id"))
       .groupBy("label", "category", "datasourceId")
       .agg(collect_set("ensemblGeneId").as("entityIds"))


### PR DESCRIPTION
## Context

Gene Ontology dataset is now updated with slight changes in the schema. Eg. the column `name` is now renamed to `label`, so no need to do the renaming in etl.