### PR TITLE
fix(openfda): remove linkedTargets field no longer present in ChEMBL input

### DIFF
--- a/src/main/scala/io/opentargets/etl/backend/openfda/stage/PrepareDrugList.scala
+++ b/src/main/scala/io/opentargets/etl/backend/openfda/stage/PrepareDrugList.scala
@@ -12,8 +12,7 @@ object PrepareDrugList extends LazyLogging {
         "id as chembl_id",
         "synonyms as synonyms",
         "name as pref_name",
-        "tradeNames as trade_names",
-        "linkedTargets as linkedTargets"
+        "tradeNames as trade_names"
       )
       .withColumn(
         "drug_names",
@@ -21,7 +20,7 @@ object PrepareDrugList extends LazyLogging {
       )
       .withColumn("_drug_name", explode(col("drug_names")))
       .withColumn("drug_name", lower(col("_drug_name")))
-      .select("chembl_id", "drug_name", "linkedTargets")
+      .select("chembl_id", "drug_name")
       .distinct()
       .orderBy(col("drug_name"))
 

--- a/src/test/scala/io/opentargets/etl/backend/OpenFdaTest.scala
+++ b/src/test/scala/io/opentargets/etl/backend/OpenFdaTest.scala
@@ -45,7 +45,7 @@ class OpenFdaTest extends AnyWordSpecLike with SparkSessionSetup with Matchers {
     "successfully load only drugs of interest" in {
       val drugList = PrepareDrugList(dfsData(DrugData()).data)
       val cols = drugList.columns
-      val expectedColumns = List("chembl_id", "drug_name", "linkedTargets")
+      val expectedColumns = List("chembl_id", "drug_name")
 
       assert(cols.length == expectedColumns.length)
       assert(cols.forall(colName => expectedColumns.contains(colName)))


### PR DESCRIPTION
## Summary

- `linkedTargets` was selected in `PrepareDrugList` but is no longer present in the ChEMBL input file
- The field was carried through the join in `OpenFdaDataPreparation` but immediately dropped by the explicit `selectExpr` in `PrepareSummaryStatistics` before any output was written — so removal has no functional impact
- Updated the corresponding test in `OpenFdaTest` to reflect the new output columns